### PR TITLE
Small changes 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ jobs:
   include:
     - stage: release
       install: true
-      script: "./gradlew githubRelease"
+      script:
+        - "./gradlew githubRelease"
+        - "./gradlew gitPublishPush"
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A detailed documentation can be found [here](https://hivemq.github.io/mqtt-cli)
 - **All MQTT 3.1.1 and MQTT 5.0 features** are supported
 - **interactive**, direct and verbose Mode for all MQTT Commands
 - Shell behavior with Syntax Highlighting, Command completion and history
-- configurable Default settings
+- configurable default settings
 - Ability to connect simultaneously various MQTT Clients to different Broker
 - Various distributions available
 - Graal support coming soon
@@ -102,7 +102,7 @@ Therefore methods like Connect and Disconnect switch the current context of the 
 ```
 mqtt shell                # starts the shell
 
-mqtt> con -i myClient            # connect client with identifier
+mqtt> con -i myClient           # connect client with identifier
 myClient> pub -t test -m msg    # publish with new context client
 myClient> dis                   # disconnect and remove context
 mqtt> ...

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ compileTestJava {
 }
 
 group = 'com.hivemq'
-version = '1.0.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
+version = '1.0.1' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
 description = 'MQTT CLI is a tool that provides a feature rich command line interface for connecting, ' +
         'publishing, subscribing, unsubscribing and disconnecting ' +
         'various MQTT clients simultaneously and supports  MQTT 5.0 and MQTT 3.1.1 '

--- a/build.gradle
+++ b/build.gradle
@@ -475,13 +475,13 @@ githubRelease {
     owner = project.githubOrg
     targetCommitish "develop"
     body ""
-    draft false
+    draft true
     prerelease false
     releaseAssets file("${project.buildRpmDir}/${project.readableName}-${project.version}.noarch.rpm"),
             file("${project.buildDebDir}/${project.readableName}_${project.version}_all.deb"),
             file("${project.buildBrewDir}/${project.readableName}-${project.version}-brew.zip"),
             buildWindowsZip
-    overwrite true
+    overwrite false
 }
 
 gitPublish {

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
     id 'com.palantir.graal' version '0.6.0'
     id 'de.thetaphi.forbiddenapis' version '2.6' apply false
     id "com.github.breadmoirai.github-release" version "2.2.9"
+    id 'org.ajoberstar.git-publish' version '2.1.1'
 }
 
 apply plugin: 'de.thetaphi.forbiddenapis'
@@ -481,6 +482,21 @@ githubRelease {
             file("${project.buildBrewDir}/${project.readableName}-${project.version}-brew.zip"),
             buildWindowsZip
     overwrite true
+}
+
+gitPublish {
+    repoUri = "https://github.com/hivemq/homebrew-mqtt-cli.git"
+
+    branch = 'master'
+
+    contents {
+        from(project.buildBrewDir) {
+            include 'mqtt-cli.rb'
+        }
+    }
+
+    // message used when committing changes
+    commitMessage = "Release version v${project.version}"
 }
 
 

--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -129,7 +129,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
 
         // build trustManagerFactory for server side authentication and to enable tls
         TrustManagerFactory trustManagerFactory = null;
-        if (!certificates.isEmpty()) {
+        if (certificates != null && !certificates.isEmpty()) {
             trustManagerFactory = buildTrustManagerFactory(certificates);
         }
 

--- a/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
@@ -124,14 +124,15 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
         logUnusedOptions();
 
         try {
+            qos = MqttUtils.arrangeQosToMatchTopics(topics, qos);
             mqttClientExecutor.publish(this);
         }
         catch (final Exception ex) {
             if (ex instanceof ConnectionFailedException) {
-                LoggingContext.put("identifier", "CONNECT");
+                LoggingContext.put("identifier", "CONNECT ERROR:");
             }
             else {
-                LoggingContext.put("identifier", "PUBLISH");
+                LoggingContext.put("identifier", "SUBSCRIBE ERROR:");
             }
             if (isVerbose()) {
                 Logger.trace(ex);

--- a/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
@@ -132,7 +132,7 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
                 LoggingContext.put("identifier", "CONNECT ERROR:");
             }
             else {
-                LoggingContext.put("identifier", "SUBSCRIBE ERROR:");
+                LoggingContext.put("identifier", "PUBLISH ERROR:");
             }
             if (isVerbose()) {
                 Logger.trace(ex);

--- a/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
@@ -118,7 +118,7 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
                 LoggingContext.put("identifier", "CONNECT ERROR:");
             }
             else {
-                LoggingContext.put("identifier", "PUBLISH ERROR:");
+                LoggingContext.put("identifier", "SUBSCRIBE ERROR:");
             }
             if (isVerbose()) {
                 Logger.trace(ex);

--- a/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
@@ -87,7 +87,7 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
     @Nullable
     private File receivedMessagesFile;
 
-    @CommandLine.Option(names = {"-oc", "--outputToConsole"}, defaultValue = "false", description = "The received messages will be written to the console (default: false)", order = 1)
+    @CommandLine.Option(names = {"-oc", "--outputToConsole"}, hidden = true, defaultValue = "true", description = "The received messages will be written to the console (default: true)", order = 1)
     private boolean printToSTDOUT;
 
     @CommandLine.Option(names = {"-b64", "--base64"}, description = "Specify the encoding of the received messages as Base64 (default: false)", order = 1)
@@ -129,9 +129,6 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
             Logger.error(MqttUtils.getRootCause(ex).getMessage());
         }
 
-        if (receivedMessagesFile == null && !printToSTDOUT) {
-            printToSTDOUT = true;
-        }
         try {
             stay();
         }

--- a/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
@@ -76,7 +76,7 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
     @NotNull
     private String[] topics;
 
-    @CommandLine.Option(names = {"-q", "--qos"}, converter = MqttQosConverter.class, defaultValue = "2", description = "Quality of service for the corresponding topics (default for all: 0)", order = 1)
+    @CommandLine.Option(names = {"-q", "--qos"}, converter = MqttQosConverter.class, defaultValue = "2", description = "Quality of service for the corresponding topics (default for all: 2)", order = 1)
     @NotNull
     private MqttQos[] qos;
 
@@ -115,10 +115,10 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
         }
         catch (final Exception ex) {
             if (ex instanceof ConnectionFailedException) {
-                LoggingContext.put("identifier", "CONNECT");
+                LoggingContext.put("identifier", "CONNECT ERROR:");
             }
             else {
-                LoggingContext.put("identifier", "PUBLISH");
+                LoggingContext.put("identifier", "PUBLISH ERROR:");
             }
             if (isVerbose()) {
                 Logger.trace(ex);

--- a/src/main/java/com/hivemq/cli/commands/shell/ContextPublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ContextPublishCommand.java
@@ -106,6 +106,7 @@ public class ContextPublishCommand extends ShellContextCommand implements Runnab
         }
 
         try {
+            qos = MqttUtils.arrangeQosToMatchTopics(topics, qos);
             mqttClientExecutor.publish(contextClient, this);
         }
         catch (final Exception ex) {

--- a/src/main/java/com/hivemq/cli/commands/shell/ContextSubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ContextSubscribeCommand.java
@@ -67,7 +67,7 @@ public class ContextSubscribeCommand extends ShellContextCommand implements Runn
     @NotNull
     private String[] topics;
 
-    @CommandLine.Option(names = {"-q", "--qos"}, converter = MqttQosConverter.class, defaultValue = "2", description = "Quality of service for the corresponding topics (default for all: 0)")
+    @CommandLine.Option(names = {"-q", "--qos"}, converter = MqttQosConverter.class, defaultValue = "2", description = "Quality of service for the corresponding topics (default for all: 2)")
     @NotNull
     private MqttQos[] qos;
 

--- a/src/main/java/com/hivemq/cli/commands/shell/ContextSubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ContextSubscribeCommand.java
@@ -81,7 +81,7 @@ public class ContextSubscribeCommand extends ShellContextCommand implements Runn
     @CommandLine.Option(names = {"-oc", "--outputToConsole"}, defaultValue = "false", description = "The received messages will be written to the console (default: false)")
     private boolean printToSTDOUT;
 
-    @CommandLine.Option(names = {"-s", "--stay"}, hidden = true, defaultValue = "false", description = "The subscribe will block the console and wait for publish messages to print (default: false)")
+    @CommandLine.Option(names = {"-s", "--stay"}, defaultValue = "false", description = "The subscribe will block the console and wait for publish messages to print (default: false)")
     private boolean stay;
 
     @CommandLine.Option(names = {"-b64", "--base64"}, description = "Specify the encoding of the received messages as Base64 (default: false)")

--- a/src/main/java/com/hivemq/cli/commands/shell/ShellCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ShellCommand.java
@@ -64,6 +64,8 @@ public class ShellCommand implements Runnable {
     public static boolean VERBOSE;
     private String logfilePath;
 
+    public static PrintWriter TERMINAL_WRITER;
+
     private static LineReaderImpl currentReader;
     private static LineReaderImpl shellReader;
     private static LineReaderImpl contextReader;
@@ -153,9 +155,9 @@ public class ShellCommand implements Runnable {
             readFromShell();
 
 
-            final PrintWriter terminalWriter = terminal.writer();
-            terminalWriter.println(shellCommandLine.getUsageMessage());
-            terminalWriter.flush();
+            TERMINAL_WRITER = terminal.writer();
+            TERMINAL_WRITER.println(shellCommandLine.getUsageMessage());
+            TERMINAL_WRITER.flush();
 
             Logger.info("Using default values from properties file {}:", PropertiesUtils.PROPERTIES_FILE_PATH);
             Logger.info("Host: {}, Port: {}, Mqtt-Version {}, Shell-Debug-Level: {}",
@@ -230,6 +232,7 @@ public class ShellCommand implements Runnable {
     }
 
     static void readFromShell() {
+
         currentReader = shellReader;
         currentCommandLine = shellCommandLine;
         prompt = new AttributedStringBuilder()

--- a/src/main/java/com/hivemq/cli/commands/shell/ShellContextCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ShellContextCommand.java
@@ -53,7 +53,7 @@ public class ShellContextCommand implements Runnable, CliCommand {
         this.mqttClientExecutor = mqttClientExecutor;
     }
 
-    static void updateContext(final @Nullable MqttClient client) {
+    public static void updateContext(final @Nullable MqttClient client) {
         if (client != null && client.getConfig().getState().isConnectedOrReconnect()) {
             if (ShellCommand.isVerbose()) {
                 Logger.trace("Update context to {}@{}", client.getConfig().getClientIdentifier().get(), client.getConfig().getServerHost());
@@ -64,7 +64,7 @@ public class ShellContextCommand implements Runnable, CliCommand {
         }
     }
 
-    static void removeContext() {
+    public static void removeContext() {
         if (ShellCommand.isVerbose()) {
             Logger.trace("Remove context");
         }

--- a/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
@@ -92,7 +92,9 @@ abstract class AbstractMqttClientExecutor {
 
         for (int i = 0; i < subscribe.getTopics().length; i++) {
             final String topic = subscribe.getTopics()[i];
-            final MqttQos qos = subscribe.getQos()[i];
+
+            int qosI = i < subscribe.getQos().length ? i: subscribe.getQos().length-1;
+            final MqttQos qos = subscribe.getQos()[qosI];
 
             switch (client.getConfig().getMqttVersion()) {
                 case MQTT_5_0:
@@ -117,7 +119,8 @@ abstract class AbstractMqttClientExecutor {
 
         for (int i = 0; i < publish.getTopics().length; i++) {
             final String topic = publish.getTopics()[i];
-            final MqttQos qos = publish.getQos()[i];
+            int qosI = i < publish.getQos().length ? i: publish.getQos().length-1;
+            final MqttQos qos = publish.getQos()[qosI];
 
             switch (client.getConfig().getMqttVersion()) {
                 case MQTT_5_0:

--- a/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
@@ -19,10 +19,14 @@ package com.hivemq.cli.mqtt;
 import com.hivemq.cli.commands.*;
 import com.hivemq.cli.commands.cli.PublishCommand;
 import com.hivemq.cli.commands.cli.SubscribeCommand;
+import com.hivemq.cli.commands.shell.ShellCommand;
+import com.hivemq.cli.commands.shell.ShellContextCommand;
+import com.hivemq.cli.utils.MqttUtils;
 import com.hivemq.client.mqtt.MqttClient;
 import com.hivemq.client.mqtt.MqttClientBuilder;
 import com.hivemq.client.mqtt.MqttClientState;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.lifecycle.MqttDisconnectSource;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
@@ -44,8 +48,10 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5WillPublish;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5WillPublishBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jline.terminal.Terminal;
 import org.pmw.tinylog.Logger;
 import org.pmw.tinylog.LoggingContext;
+import org.w3c.dom.ls.LSOutput;
 
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
@@ -372,6 +378,7 @@ abstract class AbstractMqttClientExecutor {
     private @NotNull MqttClientBuilder createBuilder(final @NotNull Connect connect) {
 
         return MqttClient.builder()
+                .addDisconnectedListener(new ContextClientDisconnectListener())
                 .serverHost(connect.getHost())
                 .serverPort(connect.getPort())
                 .sslConfig(connect.getSslConfig())

--- a/src/main/java/com/hivemq/cli/mqtt/ContextClientDisconnectListener.java
+++ b/src/main/java/com/hivemq/cli/mqtt/ContextClientDisconnectListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.hivemq.cli.mqtt;
+
+import com.hivemq.cli.commands.shell.ShellCommand;
+import com.hivemq.cli.commands.shell.ShellContextCommand;
+import com.hivemq.cli.utils.MqttUtils;
+import com.hivemq.client.mqtt.lifecycle.MqttClientDisconnectedContext;
+import com.hivemq.client.mqtt.lifecycle.MqttClientDisconnectedListener;
+import org.jetbrains.annotations.NotNull;
+import org.pmw.tinylog.Logger;
+
+public class ContextClientDisconnectListener implements MqttClientDisconnectedListener {
+
+    @Override
+    public void onDisconnected(final @NotNull MqttClientDisconnectedContext context) {
+
+        final Throwable cause = context.getCause();
+
+        if (ShellCommand.VERBOSE) {
+            Logger.trace(cause);
+        }
+        else if (ShellCommand.DEBUG) {
+            Logger.debug(cause.getMessage());
+        }
+
+        if (context.getClientConfig().equals(ShellContextCommand.contextClient.getConfig())) {
+            Logger.error(MqttUtils.getRootCause(cause).getMessage());
+            ShellContextCommand.removeContext();
+            ShellCommand.TERMINAL_WRITER.printf("Press ENTER to resume: ");
+            ShellCommand.TERMINAL_WRITER.flush();
+        }
+    }
+}

--- a/src/main/java/com/hivemq/cli/mqtt/MqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/MqttClientExecutor.java
@@ -144,19 +144,24 @@ public class MqttClientExecutor extends AbstractMqttClientExecutor {
             Logger.debug("sending SUBSCRIBE: (Topic: {}, QoS: {})", topic, qos);
         }
 
+        final boolean printToSTDOUT = subscribe.isPrintToSTDOUT();
+
         client.subscribe(subscribeMessage, publish -> {
 
-                    byte[] payload = publish.getPayloadAsBytes();
-                    final String payloadMessage = applyBase64EncodingIfSet(subscribe.isBase64(), payload);
+            byte[] payload = publish.getPayloadAsBytes();
+            final String payloadMessage = applyBase64EncodingIfSet(subscribe.isBase64(), payload);
 
-                    if (finalFileWriter != null) {
-                        finalFileWriter.println(publish.getTopic() + ": " + payloadMessage);
-                        finalFileWriter.flush();
-                    }
+            if (!getClientDataMap().get(subscribe.getKey()).getSubscribedTopics().contains(topic)) {
 
-                    if (subscribe.isPrintToSTDOUT()) {
-                        System.out.println(payloadMessage);
-                    }
+                if (finalFileWriter != null) {
+                    finalFileWriter.println(publish.getTopic() + ": " + payloadMessage);
+                    finalFileWriter.flush();
+                }
+
+                if (printToSTDOUT) {
+                    System.out.println(payloadMessage);
+                }
+            }
 
             if (subscribe.isVerbose()) {
                 Logger.trace("received PUBLISH: {}", publish);
@@ -220,19 +225,24 @@ public class MqttClientExecutor extends AbstractMqttClientExecutor {
             Logger.debug("sending SUBSCRIBE: (Topic: {}, QoS: {})", topic, qos);
         }
 
+        final boolean printToSTDOUT = subscribe.isPrintToSTDOUT();
+
         client.subscribe(subscribeMessage, publish -> {
 
                     byte[] payload = publish.getPayloadAsBytes();
                     final String payloadMessage = applyBase64EncodingIfSet(subscribe.isBase64(), payload);
 
-                    if (finalFileWriter != null) {
-                        finalFileWriter.println(publish.getTopic() + ": " + payloadMessage);
-                        finalFileWriter.flush();
-                    }
+            if (!getClientDataMap().get(subscribe.getKey()).getSubscribedTopics().contains(topic)) {
 
-                    if (subscribe.isPrintToSTDOUT()) {
-                        System.out.println(payloadMessage);
-                    }
+                if (finalFileWriter != null) {
+                    finalFileWriter.println(publish.getTopic() + ": " + payloadMessage);
+                    finalFileWriter.flush();
+                }
+
+                if (printToSTDOUT) {
+                    System.out.println(payloadMessage);
+                }
+            }
 
             if (subscribe.isVerbose()) {
                 Logger.trace("received PUBLISH: {}", publish);


### PR DESCRIPTION
- Automatically update homebrew-mqtt-cli repository when merging into master
- Using default Ssl configuration via -s in pub, sub and con produces no longer NullPointerException
- Fix ArayIndex ooB in pub/sub if qos & topic amount does not fit
- External client disconnect is handled by cli
- -s option of subscribe with context prints only the given subscription for the command
