### PR TITLE
Fix qos1 publishes

### DIFF
--- a/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
@@ -468,10 +468,10 @@ abstract class AbstractMqttClientExecutor {
         else {
             return mqtt5Publish -> {
                 if (connect.isVerbose()) {
-                    Logger.trace("received PUBLISH: {}", mqtt5Publish);
+                    Logger.trace("received PUBLISH: {} with Message: '{}'", mqtt5Publish, new String(mqtt5Publish.getPayloadAsBytes()));
                 }
                 else if (connect.isDebug()) {
-                    Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt5Publish.getTopic(), mqtt5Publish.getPayload());
+                    Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')",mqtt5Publish.getTopic(), new String(mqtt5Publish.getPayloadAsBytes()));
                 }
             };
         }
@@ -484,10 +484,10 @@ abstract class AbstractMqttClientExecutor {
         else {
             return mqtt3Publish -> {
                 if (connect.isVerbose()) {
-                    Logger.trace("received PUBLISH: {}", mqtt3Publish);
+                    Logger.trace("received PUBLISH: {}", new String(mqtt3Publish.getPayloadAsBytes()));
                 }
                 else if (connect.isDebug()) {
-                    Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt3Publish.getTopic(), mqtt3Publish.getPayload());
+                    Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt3Publish.getTopic(), new String(mqtt3Publish.getPayloadAsBytes()));
                 }
             };
         }

--- a/src/main/java/com/hivemq/cli/mqtt/MqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/MqttClientExecutor.java
@@ -257,13 +257,13 @@ public class MqttClientExecutor extends AbstractMqttClientExecutor {
 
                             TypeSwitch.when(publishResult)
                                     .is(MqttPublishResult.MqttQos1Result.class, qos1Result -> {
-                                        Logger.debug("received PUBACK: '{}' for PUBLISH to Topic:  {}", trimMessage(p), topic);
+                                        Logger.debug("received PUBACK: '{}' for PUBLISH to Topic: {}", trimMessage(p), topic);
                                     })
                                     .is(MqttPublishResult.MqttQos2Result.class, qos2Result -> {
-                                        Logger.debug("received PUBREC: '{}' for PUBLISH to Topic:  {}", trimMessage(p), topic);
+                                        Logger.debug("received PUBREC: '{}' for PUBLISH to Topic: {}", trimMessage(p), topic);
                                     })
                                     .is(MqttPublishResult.class, qos0Result -> {
-                                        Logger.debug("acknowledged PUBLISH: '{}' for PUBLISH to Topic:  {}", trimMessage(p), topic);
+                                        Logger.debug("acknowledged PUBLISH: '{}' for PUBLISH to Topic: {}", trimMessage(p), topic);
                                     });
                         }
 
@@ -316,7 +316,7 @@ public class MqttClientExecutor extends AbstractMqttClientExecutor {
                             Logger.trace("acknowledged PUBLISH: '{}' for PUBLISH to Topic: {}", publishResult, topic);
                         }
                         else if (publish.isDebug()) {
-                            Logger.debug("acknowledged PUBLISH: '{}' for PUBLISH to Topic:  {}", trimMessage(p), topic);
+                            Logger.debug("acknowledged PUBLISH: '{}' for PUBLISH to Topic: {}", trimMessage(p), topic);
                         }
 
                     }

--- a/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt3PublishCallback.java
+++ b/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt3PublishCallback.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.hivemq.cli.mqtt;
+
+import com.hivemq.cli.commands.Subscribe;
+import com.hivemq.cli.utils.FileUtils;
+import com.hivemq.cli.utils.SubscribeMqttPublishCallbackUtils;
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import org.bouncycastle.util.encoders.Base64;
+import org.jetbrains.annotations.NotNull;
+import org.pmw.tinylog.Logger;
+
+import java.io.PrintWriter;
+import java.util.function.Consumer;
+
+public class SubscribeMqtt3PublishCallback implements Consumer<Mqtt3Publish> {
+
+    private final Subscribe subscribe;
+
+    public SubscribeMqtt3PublishCallback(final @NotNull Subscribe subscribe) {
+        this.subscribe = subscribe;
+    }
+
+    @Override
+    public void accept(Mqtt3Publish mqtt3Publish) {
+
+        PrintWriter fileWriter = null;
+        if (subscribe.getReceivedMessagesFile() != null) {
+            fileWriter = FileUtils.createFileAppender(subscribe.getReceivedMessagesFile());
+        }
+
+
+        byte[] payload = mqtt3Publish.getPayloadAsBytes();
+        final String payloadMessage = SubscribeMqttPublishCallbackUtils.applyBase64EncodingIfSet(subscribe.isBase64(), payload);
+
+        if (fileWriter != null) {
+            fileWriter.println(mqtt3Publish.getTopic() + ": " + payloadMessage);
+            fileWriter.flush();
+            fileWriter.close();
+        }
+
+        if (subscribe.isPrintToSTDOUT()) {
+            System.out.println(payloadMessage);
+        }
+
+        if (subscribe.isVerbose()) {
+            Logger.trace("received PUBLISH: {}", mqtt3Publish);
+        }
+        else if (subscribe.isDebug()) {
+            Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt3Publish.getTopic(), payloadMessage);
+        }
+
+    }
+
+}

--- a/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt3PublishCallback.java
+++ b/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt3PublishCallback.java
@@ -59,10 +59,10 @@ public class SubscribeMqtt3PublishCallback implements Consumer<Mqtt3Publish> {
         }
 
         if (subscribe.isVerbose()) {
-            Logger.trace("received PUBLISH: {}", mqtt3Publish);
+            Logger.trace("received PUBLISH: {} with Message: '{}'", mqtt3Publish, new String(mqtt3Publish.getPayloadAsBytes()));
         }
         else if (subscribe.isDebug()) {
-            Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt3Publish.getTopic(), payloadMessage);
+            Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt3Publish.getTopic(), new String(mqtt3Publish.getPayloadAsBytes()));
         }
 
     }

--- a/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt5PublishCallback.java
+++ b/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt5PublishCallback.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.hivemq.cli.mqtt;
+
+import com.hivemq.cli.commands.Subscribe;
+import com.hivemq.cli.utils.FileUtils;
+import com.hivemq.cli.utils.SubscribeMqttPublishCallbackUtils;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import org.jetbrains.annotations.NotNull;
+import org.pmw.tinylog.Logger;
+
+import java.io.PrintWriter;
+import java.util.function.Consumer;
+
+public class SubscribeMqtt5PublishCallback implements Consumer<Mqtt5Publish> {
+
+    private final Subscribe subscribe;
+
+    public SubscribeMqtt5PublishCallback(final @NotNull Subscribe subscribe) {
+        this.subscribe = subscribe;
+    }
+
+    @Override
+    public void accept(Mqtt5Publish mqtt5Publish) {
+
+        PrintWriter fileWriter = null;
+        if (subscribe.getReceivedMessagesFile() != null) {
+            fileWriter = FileUtils.createFileAppender(subscribe.getReceivedMessagesFile());
+        }
+
+
+        byte[] payload = mqtt5Publish.getPayloadAsBytes();
+        final String payloadMessage = SubscribeMqttPublishCallbackUtils.applyBase64EncodingIfSet(subscribe.isBase64(), payload);
+
+        if (fileWriter != null) {
+            fileWriter.println(mqtt5Publish.getTopic() + ": " + payloadMessage);
+            fileWriter.flush();
+            fileWriter.close();
+        }
+
+        if (subscribe.isPrintToSTDOUT()) {
+            System.out.println(payloadMessage);
+        }
+
+        if (subscribe.isVerbose()) {
+            Logger.trace("received PUBLISH: {}", mqtt5Publish);
+        }
+        else if (subscribe.isDebug()) {
+            Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt5Publish.getTopic(), payloadMessage);
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt5PublishCallback.java
+++ b/src/main/java/com/hivemq/cli/mqtt/SubscribeMqtt5PublishCallback.java
@@ -57,10 +57,10 @@ public class SubscribeMqtt5PublishCallback implements Consumer<Mqtt5Publish> {
         }
 
         if (subscribe.isVerbose()) {
-            Logger.trace("received PUBLISH: {}", mqtt5Publish);
+            Logger.trace("received PUBLISH: {} with Message: '{}'", mqtt5Publish, new String(mqtt5Publish.getPayloadAsBytes()));
         }
         else if (subscribe.isDebug()) {
-            Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt5Publish.getTopic(), payloadMessage);
+            Logger.debug("received PUBLISH: (Topic: {}, Message: '{}')", mqtt5Publish.getTopic(), new String(mqtt5Publish.getPayloadAsBytes()));
         }
 
     }

--- a/src/main/java/com/hivemq/cli/utils/SubscribeMqttPublishCallbackUtils.java
+++ b/src/main/java/com/hivemq/cli/utils/SubscribeMqttPublishCallbackUtils.java
@@ -1,0 +1,16 @@
+package com.hivemq.cli.utils;
+
+import org.bouncycastle.util.encoders.Base64;
+import org.jetbrains.annotations.NotNull;
+
+
+public class SubscribeMqttPublishCallbackUtils {
+
+    public static @NotNull String applyBase64EncodingIfSet(final boolean encode, final byte[] payload) {
+        if (encode) {
+            return Base64.toBase64String(payload);
+        } else {
+            return new String(payload);
+        }
+    }
+}

--- a/src/main/java/com/hivemq/cli/utils/SubscribeMqttPublishCallbackUtils.java
+++ b/src/main/java/com/hivemq/cli/utils/SubscribeMqttPublishCallbackUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package com.hivemq.cli.utils;
 
 import org.bouncycastle.util.encoders.Base64;


### PR DESCRIPTION
**Motivation**

* Fix bug #97 of not receiving any QoS1 ouput after reconnecting

**Changes**

* Fix the bug by registering a callback before the client connects to consume *remaining* publishes
* Refactor the publish callbacks of the `mqtt3Subscribe` and `mqtt5Subscribe` methods in a dedicated class called `SubscribeMqtt3PublishCallback`and `SubscribeMqtt5PublishCallback`
* Make the logging of received publishes more meaningful by always printing the payload message in every debug level
