### PR TITLE
Add password input from environment variable and file

### DIFF
--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -18,9 +18,7 @@ package com.hivemq.cli.commands;
 
 import com.hivemq.cli.converters.*;
 import com.hivemq.cli.utils.MqttUtils;
-import com.hivemq.client.mqtt.MqttClient;
 import com.hivemq.client.mqtt.MqttClientSslConfig;
-import com.hivemq.client.mqtt.MqttVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.pmw.tinylog.Logger;
@@ -36,7 +34,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlags implements Connect {
 
@@ -49,6 +46,16 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
     @CommandLine.Option(names = {"-pw", "--password"}, arity = "0..1", interactive = true, converter = ByteBufferConverter.class, description = "The password for authentication", order = 2)
     @Nullable
     private ByteBuffer password;
+
+    @CommandLine.Option(names = {"-pw:env"}, converter = EnvVarToByteBufferConverter.class, description = "The password for authentication read in from an environment variable", order = 2)
+    private void setPasswordFromEnv(final @NotNull ByteBuffer passwordEnvironmentVariable) {
+        password = passwordEnvironmentVariable;
+    }
+
+    @CommandLine.Option(names = {"-pw:file"}, converter = FileToByteBufferConverter.class, description = "The password for authentication read in from a file", order = 2)
+    private void setPasswordFromFile(final @NotNull ByteBuffer passwordFromFile) {
+        password = passwordFromFile;
+    }
 
     @CommandLine.Option(names = {"-k", "--keepAlive"}, converter = UnsignedShortConverter.class, description = "A keep alive of the client (in seconds) (default: 60)", order = 2)
     private @Nullable Integer keepAlive;
@@ -81,7 +88,6 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
 
     @CommandLine.Option(names = {"--key"}, converter = FileToPrivateKeyConverter.class, description = "The path to the client private key for client side authentication", order = 2)
     @Nullable PrivateKey clientPrivateKey;
-
 
 
     public @Nullable MqttClientSslConfig buildSslConfig() {

--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -47,7 +47,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
     @Nullable
     private ByteBuffer password;
 
-    @CommandLine.Option(names = {"-pw:env"}, converter = EnvVarToByteBufferConverter.class, description = "The password for authentication read in from an environment variable", order = 2)
+    @CommandLine.Option(names = {"-pw:env"}, arity = "0..1",converter = EnvVarToByteBufferConverter.class, fallbackValue = "MQTT_CLI_PW", description = "The password for authentication read in from an environment variable", order = 2)
     private void setPasswordFromEnv(final @NotNull ByteBuffer passwordEnvironmentVariable) {
         password = passwordEnvironmentVariable;
     }

--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -47,10 +47,8 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
     @Nullable
     private ByteBuffer password;
 
-    @CommandLine.Option(names = {"-pw:env"}, arity = "0..1",converter = EnvVarToByteBufferConverter.class, fallbackValue = "MQTT_CLI_PW", description = "The password for authentication read in from an environment variable", order = 2)
-    private void setPasswordFromEnv(final @NotNull ByteBuffer passwordEnvironmentVariable) {
-        password = passwordEnvironmentVariable;
-    }
+    @CommandLine.Option(names = {"-pw:env"}, arity = "0..1", converter = EnvVarToByteBufferConverter.class, fallbackValue = "MQTT_CLI_PW", description = "The password for authentication read in from an environment variable", order = 2)
+    private void setPasswordFromEnv(final @NotNull ByteBuffer passwordEnvironmentVariable) { password = passwordEnvironmentVariable; }
 
     @CommandLine.Option(names = {"-pw:file"}, converter = FileToByteBufferConverter.class, description = "The password for authentication read in from a file", order = 2)
     private void setPasswordFromFile(final @NotNull ByteBuffer passwordFromFile) {

--- a/src/main/java/com/hivemq/cli/converters/ByteBufferConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/ByteBufferConverter.java
@@ -27,6 +27,6 @@ public class ByteBufferConverter implements CommandLine.ITypeConverter<ByteBuffe
 
     @Override
     public ByteBuffer convert(final @NotNull String s) throws Exception {
-        return ByteBuffer.wrap(s.getBytes());
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/hivemq/cli/converters/ByteBufferConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/ByteBufferConverter.java
@@ -27,6 +27,6 @@ public class ByteBufferConverter implements CommandLine.ITypeConverter<ByteBuffe
 
     @Override
     public ByteBuffer convert(final @NotNull String s) throws Exception {
-        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+        return ByteBuffer.wrap(s.getBytes());
     }
 }

--- a/src/main/java/com/hivemq/cli/converters/EnvVarToByteBufferConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/EnvVarToByteBufferConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.hivemq.cli.converters;
+
+import picocli.CommandLine;
+
+import java.nio.ByteBuffer;
+
+public class EnvVarToByteBufferConverter implements CommandLine.ITypeConverter<ByteBuffer> {
+
+    static final String ENVIRONMENT_VARIABLE_IS_NULL = "The given environment variable is not defined.";
+
+    @Override
+    public ByteBuffer convert(String value) throws Exception {
+        final ByteBufferConverter converter = new ByteBufferConverter();
+        final String envVar = System.getenv(value);
+
+        if (envVar == null) {
+            throw new NullPointerException(ENVIRONMENT_VARIABLE_IS_NULL);
+        }
+
+        return converter.convert(envVar);
+    }
+}

--- a/src/main/java/com/hivemq/cli/converters/FileConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileConverter.java
@@ -1,0 +1,42 @@
+package com.hivemq.cli.converters;
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+class FileConverter implements CommandLine.ITypeConverter<File> {
+
+    static final String FILE_NOT_FOUND = "The given file was not found.";
+    static final String NOT_A_FILE = "The given path does not lead to a valid file.";
+
+    @Override
+    public File convert(String value) throws Exception {
+
+        final File file = new File(value);
+
+        if (!file.exists())
+            throw new FileNotFoundException(FILE_NOT_FOUND);
+
+        if (!file.isFile())
+            throw new IllegalArgumentException(NOT_A_FILE);
+
+
+        return file;
+    }
+}

--- a/src/main/java/com/hivemq/cli/converters/FileToByteBufferConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToByteBufferConverter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.hivemq.cli.converters;
+
+import picocli.CommandLine;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+
+public class FileToByteBufferConverter implements CommandLine.ITypeConverter<ByteBuffer> {
+    @Override
+    public ByteBuffer convert(String value) throws Exception {
+        final ByteBufferConverter byteBufferConverter = new ByteBufferConverter();
+        final FileConverter fileConverter = new FileConverter();
+
+        final File file = fileConverter.convert(value);
+        final String password = new String(Files.readAllBytes(file.toPath()));
+
+        return byteBufferConverter.convert(password);
+    }
+}

--- a/src/main/java/com/hivemq/cli/converters/FileToByteBufferConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToByteBufferConverter.java
@@ -25,12 +25,10 @@ import java.nio.file.Files;
 public class FileToByteBufferConverter implements CommandLine.ITypeConverter<ByteBuffer> {
     @Override
     public ByteBuffer convert(String value) throws Exception {
-        final ByteBufferConverter byteBufferConverter = new ByteBufferConverter();
         final FileConverter fileConverter = new FileConverter();
 
         final File file = fileConverter.convert(value);
-        final String password = new String(Files.readAllBytes(file.toPath()));
 
-        return byteBufferConverter.convert(password);
+        return ByteBuffer.wrap(Files.readAllBytes(file.toPath()));
     }
 }

--- a/src/main/java/com/hivemq/cli/converters/FileToCertificateConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToCertificateConverter.java
@@ -27,21 +27,13 @@ import java.util.Arrays;
 
 public class FileToCertificateConverter implements CommandLine.ITypeConverter<X509Certificate> {
 
-
-    static final String FILE_NOT_FOUND = "The given certificate file was not found.";
     static final String NO_VALID_FILE_EXTENSION = "The given file does not conform to a valid Certificate File Extension as " + Arrays.toString(CertificateConverterUtils.FILE_EXTENSIONS);
-    static final String NOT_A_FILE = "The given path is not a valid file.";
 
     @Override
     public X509Certificate convert(final @NotNull String s) throws Exception {
 
-        final File keyFile = new File(s);
-
-        if (!keyFile.exists())
-            throw new FileNotFoundException(FILE_NOT_FOUND);
-
-        if (!keyFile.isFile())
-            throw new IllegalArgumentException(NOT_A_FILE);
+        FileConverter fileConverter = new FileConverter();
+        final File keyFile = fileConverter.convert(s);
 
         final boolean correctExtension = CertificateConverterUtils.endsWithValidExtension(keyFile.getName());
 

--- a/src/main/java/com/hivemq/cli/converters/FileToPrivateKeyConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToPrivateKeyConverter.java
@@ -44,7 +44,8 @@ public class FileToPrivateKeyConverter implements CommandLine.ITypeConverter<Pri
 
     @Override
     public PrivateKey convert(final @NotNull String s) throws Exception {
-        final File keyFile = new File(s);
+        final FileConverter fileConverter = new FileConverter();
+        final File keyFile = fileConverter.convert(s);
         return getPrivateKeyFromFile(keyFile);
     }
 

--- a/src/test/java/com/hivemq/cli/converters/FileToCertificateConverterTest.java
+++ b/src/test/java/com/hivemq/cli/converters/FileToCertificateConverterTest.java
@@ -63,7 +63,7 @@ class FileToCertificateConverterTest {
     @Test
     void convert_FileNotFound() {
         Exception e = assertThrows(FileNotFoundException.class, () -> fileToCertificateConverter.convert("wrongPathXYZ.pem"));
-        assertEquals(FileToCertificateConverter.FILE_NOT_FOUND, e.getMessage());
+        assertEquals(FileConverter.FILE_NOT_FOUND, e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
**Motivation**
resolve #103 

Most of the time it is not a best practice to read in passwords in the command line in clear text like `mqtt> con -i myClient -u gitseti -pw mypassword`. Therefore, it is already possible to omit the password text so that the cli will prompt the user to enter the password in a masked input field. 

Nevertheless, this input field shows some limitations (like the input being kept to a specific internal buffer size) so that another option for securely reading in a password is needed.

Therefore, this PR introduces two new sources for password input:
- Environment variable
- File

These options can be specified in `con`, `mqtt pub` and `mqtt sub` as follows:
```
$ export PASSWORD mypassword
mqtt> con -i myClient -u gitseti -pw:env PASSWORD
```
```
$ echo mypassword > password.txt
mqtt> con -i myClient -u gitseti -pw:file password.txt
```

**Changes**
* Refactor file conversion into an own class
* Add converters for converting a file and an environment variable to a ByteBuffer