### PR TITLE
fix a bug:

### DIFF
--- a/src/main/java/com/hivemq/cli/DefaultCLIProperties.java
+++ b/src/main/java/com/hivemq/cli/DefaultCLIProperties.java
@@ -80,6 +80,7 @@ public class DefaultCLIProperties {
        put(PASSWORD_ENV, null);
        put(CLIENT_CERTIFICATE, null);
        put(CLIENT_PRIVATE_KEY, null);
+       put(SERVER_CERTIFICATE, null);
        put(WEBSOCKET_PATH, "/mqtt");
     }};
 

--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -139,6 +139,9 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
         try {
             final X509Certificate defaultServerCertificate = defaultCLIProperties.getServerCertificate();
             if (defaultServerCertificate != null) {
+                if(certificates == null){
+                    certificates = new ArrayList<>();
+                }
                 certificates.add(defaultServerCertificate);
             }
         } catch (Exception e) {


### PR DESCRIPTION
**Motivation**

When config auth.server.cafile in config.properties,Command Line doesn't take effect.It also need to add --cafile in command line.

Now I fix the bug.We Can specify the CA certificate both in config.properties and command line.



**Changes**
add line 83 in DefaultCLIProperties.java----put(SERVER_CERTIFICATE, null);
add line 142 to 144 in AbstractCommonFlags.java----initialize certificates collection