### PR TITLE
Remove duplicate .jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,9 +322,6 @@ task buildPackageBrew(type: Zip) {
     archiveFileName = project.readableName + '-' + project.version + '-brew.zip'
     destinationDirectory = file(project.buildBrewDir)
 
-    from shadowJar.archiveFile
-    from "$brewDir/mqtt"
-
     into('brew') {
         from shadowJar.archiveFile
         from "$brewDir/mqtt"

--- a/packages/homebrew/mqtt-cli.rb
+++ b/packages/homebrew/mqtt-cli.rb
@@ -7,7 +7,7 @@ class MqttCli < Formula
 
   def install
     inreplace "brew/mqtt", "##PREFIX##", "#{prefix}/mqtt-cli-@@version@@.jar"
-    prefix.install "mqtt-cli-@@version@@.jar"
+    prefix.install "brew/mqtt-cli-@@version@@.jar"
     bin.install "brew/mqtt"
   end
 


### PR DESCRIPTION
**Motivation**
Currently, the homebrew package is twice of its actual size because the jar file is duplicated.

**Changes**
- remove the jar file