### PR TITLE
Add jar as release asset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -473,7 +473,8 @@ githubRelease {
     body ""
     draft true
     prerelease false
-    releaseAssets file("${project.buildRpmDir}/${project.readableName}-${project.version}.noarch.rpm"),
+    releaseAssets file("${project.buildDir}/libs/${project.readableName}-${project.version}.jar"),
+            file("${project.buildRpmDir}/${project.readableName}-${project.version}.noarch.rpm"),
             file("${project.buildDebDir}/${project.readableName}_${project.version}_all.deb"),
             file("${project.buildBrewDir}/${project.readableName}-${project.version}-brew.zip"),
             buildWindowsZip

--- a/build.gradle
+++ b/build.gradle
@@ -473,7 +473,7 @@ githubRelease {
     body ""
     draft true
     prerelease false
-    releaseAssets file("${project.buildDir}/libs/${project.readableName}-${project.version}.jar"),
+    releaseAssets jar.archiveFile,
             file("${project.buildRpmDir}/${project.readableName}-${project.version}.noarch.rpm"),
             file("${project.buildDebDir}/${project.readableName}_${project.version}_all.deb"),
             file("${project.buildBrewDir}/${project.readableName}-${project.version}-brew.zip"),


### PR DESCRIPTION
**Motivation**
Under releases the different packages and the actual source code can be downloaded but not the actual .jar file. Therefore, this PR adds the jar file as a release asset for the created release entry.