### PR TITLE
Add Release to RPM Headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -403,6 +403,7 @@ buildDeb {
 
 buildRpm {
     arch NOARCH
+    release '1'
     requires('jre', '1.8.0', GREATER | EQUAL)
 }
 


### PR DESCRIPTION
**Motivation**
Add Release to RPM Headers to avoid errors while using RPM content management systems like Spacewalk (Red Hat Satellite 5) and potentially many others. 

Currently it's missing in the released RPM files:

```
Name        : mqtt-cli
Epoch       : 0
Version     : 1.2.0
Release     :
Architecture: noarch
Install Date: (not installed)
Group       : (none)
Size        : 17608244
License     : apache2
Signature   : (none)
Source RPM  : mqtt-cli-1.2.0--src.rpm
Build Date  : Wed Apr  8 00:12:40 2020
Build Host  : localhost
Relocations : (not relocatable)
Packager    : travis
Vendor      : HiveMQ GmbH
URL         : https://www.hivemq.com/
Summary     : MQTT Command Line Interface for interacting with a MQTT broker
Description :
MQTT CLI is a tool that provides a feature rich command line interface for connecting, publishing, subscribing, unsubscribing and disconnecting various MQTT clients simultaneously and supports  MQTT 5.0 and MQTT 3.1.1
```

I would appreciate if the released rpms are updated after fixing this. I'm particulary interested in v1.0.0.

**Changes**
add release '1' to the build task