### PR TITLE
Fix shared_subscriptions_failed() test cases

### DIFF
--- a/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandDefaultTest.java
+++ b/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandDefaultTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 @Disabled("Tests are only used to check output")
 public class TestBrokerCommandDefaultTest {
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     @BeforeAll
     static void beforeAll() {

--- a/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandQos0Test.java
+++ b/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandQos0Test.java
@@ -33,7 +33,7 @@ import java.io.File;
 public class TestBrokerCommandQos0Test {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandQos1Test.java
+++ b/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandQos1Test.java
@@ -33,7 +33,7 @@ import java.io.File;
 public class TestBrokerCommandQos1Test {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandRestrictedTest.java
+++ b/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandRestrictedTest.java
@@ -33,7 +33,7 @@ import java.io.File;
 public class TestBrokerCommandRestrictedTest {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterDefaultTest.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterDefaultTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Mqtt3FeatureTesterDefaultTest {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterQos0Test.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterQos0Test.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Mqtt3FeatureTesterQos0Test {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterQos1Test.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterQos1Test.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Mqtt3FeatureTesterQos1Test {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterRestrictedTest.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt3FeatureTesterRestrictedTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Mqtt3FeatureTesterRestrictedTest {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt3FeatureTester mqtt3FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterDefaultTest.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterDefaultTest.java
@@ -46,7 +46,7 @@ public class Mqtt5FeatureTesterDefaultTest {
 
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
      static Mqtt5FeatureTester mqtt5FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterQos0Test.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterQos0Test.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Mqtt5FeatureTesterQos0Test {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt5FeatureTester mqtt5FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterQos1Test.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterQos1Test.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Mqtt5FeatureTesterQos1Test {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt5FeatureTester mqtt5FeatureTester;
 

--- a/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterRestrictedTest.java
+++ b/src/test/java/com/hivemq/cli/mqtt/test/Mqtt5FeatureTesterRestrictedTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Mqtt5FeatureTesterRestrictedTest {
 
     final static public @NotNull HiveMQTestContainerExtension hivemq =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest");
+            new HiveMQTestContainerExtension("hivemq/hivemq4", "4.4.0");
 
     static Mqtt5FeatureTester mqtt5FeatureTester;
 


### PR DESCRIPTION
**Changes**
Set the HiveMQ docker image which is pulled by HiveMQ Testcontainer to version 4.4.0.