### PR TITLE
Fix java dependency check for homebrew

### DIFF
--- a/packages/homebrew/mqtt-cli.rb
+++ b/packages/homebrew/mqtt-cli.rb
@@ -3,7 +3,7 @@ class MqttCli < Formula
   homepage "https://www.hivemq.com"
   url "https://github.com/hivemq/mqtt-cli/releases/download/v@@version@@/@@filename@@"
   sha256 "@@shasum@@"
-  depends_on :java => "1.8+"
+  # depends_on :java => "1.8+"
 
   def install
     inreplace "brew/mqtt", "##PREFIX##", "#{prefix}/mqtt-cli-@@version@@.jar"


### PR DESCRIPTION
The homebrew java dependency check should be done in the install block.

**Motivation**
Fix #174 

