### PR TITLE
Add support for unencrypted pem files

### DIFF
--- a/src/main/java/com/hivemq/cli/converters/FileToPrivateKeyConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToPrivateKeyConverter.java
@@ -79,7 +79,10 @@ public class FileToPrivateKeyConverter implements CommandLine.ITypeConverter<Pri
             privateKey = converter.getPrivateKey(privateKeyInfo);
         } else if (object instanceof PEMKeyPair) {
             privateKey = converter.getPrivateKey(((PEMKeyPair) object).getPrivateKeyInfo());
-        } else {
+        } else if (object instanceof PrivateKeyInfo) {
+            privateKey = converter.getPrivateKey((PrivateKeyInfo) object);
+        }
+        else {
             throw new IllegalArgumentException(UNRECOGNIZED_KEY);
         }
 


### PR DESCRIPTION
**Motivation**
Currently, unencrypted `.pem` files are not supported because of a missing statement.

**Changes**

- Add PrivateKeyInfo to the `FileToPrivateKeyConverter` 