### PR TITLE
Fix certificate chains

### DIFF
--- a/src/main/java/com/hivemq/cli/DefaultCLIProperties.java
+++ b/src/main/java/com/hivemq/cli/DefaultCLIProperties.java
@@ -18,7 +18,7 @@ package com.hivemq.cli;
 
 
 import com.hivemq.cli.converters.EnvVarToByteBufferConverter;
-import com.hivemq.cli.converters.FileToCertificateConverter;
+import com.hivemq.cli.converters.FileToCertificatesConverter;
 import com.hivemq.cli.converters.FileToPrivateKeyConverter;
 import com.hivemq.cli.converters.PasswordFileToByteBufferConverter;
 import com.hivemq.client.mqtt.MqttVersion;
@@ -36,6 +36,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -250,12 +251,12 @@ public class DefaultCLIProperties {
     }
 
     @Nullable
-    public X509Certificate getClientCertificate() throws Exception {
+    public Collection<X509Certificate> getClientCertificateChain() throws Exception {
         final String clientCertificate = propertyToValue.get(CLIENT_CERTIFICATE);
         if (clientCertificate == null) {
             return null;
         }
-        return new FileToCertificateConverter().convert(clientCertificate);
+        return new FileToCertificatesConverter().convert(clientCertificate);
     }
 
     @Nullable
@@ -268,12 +269,12 @@ public class DefaultCLIProperties {
     }
 
     @Nullable
-    public X509Certificate getServerCertificate() throws Exception {
+    public Collection<X509Certificate> getServerCertificateChain() throws Exception {
         final String serverCertificate = propertyToValue.get(SERVER_CERTIFICATE);
         if (serverCertificate == null) {
             return null;
         }
-        return new FileToCertificateConverter().convert(serverCertificate);
+        return new FileToCertificatesConverter().convert(serverCertificate);
     }
 
     @NotNull

--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -19,11 +19,9 @@ package com.hivemq.cli.commands;
 import com.google.common.base.Throwables;
 import com.hivemq.cli.DefaultCLIProperties;
 import com.hivemq.cli.MqttCLIMain;
+import com.hivemq.cli.commands.options.SslOptions;
 import com.hivemq.cli.converters.ByteBufferConverter;
-import com.hivemq.cli.converters.DirectoryToCertificateCollectionConverter;
 import com.hivemq.cli.converters.EnvVarToByteBufferConverter;
-import com.hivemq.cli.converters.FileToCertificateConverter;
-import com.hivemq.cli.converters.FileToPrivateKeyConverter;
 import com.hivemq.cli.converters.PasswordFileToByteBufferConverter;
 import com.hivemq.cli.converters.UnsignedShortConverter;
 import com.hivemq.client.mqtt.MqttClientSslConfig;
@@ -33,24 +31,9 @@ import org.jetbrains.annotations.Nullable;
 import org.tinylog.Logger;
 import picocli.CommandLine;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collection;
 
 public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlags implements Connect {
-
-    private static final String DEFAULT_TLS_VERSION = "TLSv1.2";
 
     @CommandLine.Option(names = {"-u", "--user"}, description = "The username for authentication", order = 2)
     @Nullable
@@ -73,38 +56,15 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
     @Nullable
     private Boolean cleanStart;
 
-    @CommandLine.Option(names = {"-s", "--secure"}, defaultValue = "false", description = "Use default ssl configuration if no other ssl options are specified (default: false)", order = 2)
-    private boolean useSsl;
-
-    @CommandLine.Option(names = {"--cafile"}, paramLabel = "FILE", converter = FileToCertificateConverter.class, description = "Path to a file containing trusted CA certificates to enable encrypted certificate based communication", order = 2)
-    @Nullable
-    private Collection<X509Certificate> certificates;
-
-    @CommandLine.Option(names = {"--capath"}, paramLabel = "DIR", converter = DirectoryToCertificateCollectionConverter.class, description = {"Path to a directory containing certificate files to import to enable encrypted certificate based communication"}, order = 2)
-    @Nullable
-    private Collection<X509Certificate> certificatesFromDir;
-
-    @CommandLine.Option(names = {"--ciphers"}, split = ":", description = "The client supported cipher suites list in IANA format separated with ':'", order = 2)
-    @Nullable
-    private Collection<String> cipherSuites;
-
-    @CommandLine.Option(names = {"--tls-version"}, description = "The TLS protocol version to use (default: {'TLSv.1.2'})", order = 2)
-    @Nullable
-    private Collection<String> supportedTLSVersions;
-
-    @CommandLine.Option(names = {"--cert"}, converter = FileToCertificateConverter.class, description = "The client certificate to use for client side authentication", order = 2)
-    @Nullable
-    private X509Certificate clientCertificate;
-
-    @CommandLine.Option(names = {"--key"}, converter = FileToPrivateKeyConverter.class, description = "The path to the client private key for client side authentication", order = 2)
-    @Nullable
-    private PrivateKey clientPrivateKey;
+    @CommandLine.Mixin
+    private final SslOptions sslOptions = new SslOptions();
 
     @CommandLine.Option(names = {"-ws"}, description = "Use WebSocket transport protocol (default: false)", order = 2)
     private boolean useWebSocket;
 
     @CommandLine.Option(names = {"-ws:path"}, description = "The path of the WebSocket", order = 2)
-    @Nullable private String webSocketPath;
+    @Nullable
+    private String webSocketPath;
 
     @Override
     public void setDefaultOptions() {
@@ -119,149 +79,22 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
             try {
                 password = defaultCLIProperties.getPassword();
             } catch (Exception e) {
-                Logger.error(e,"Default password could not be loaded ({})", Throwables.getRootCause(e).getMessage());
+                Logger.error(e, "Default password could not be loaded ({})", Throwables.getRootCause(e).getMessage());
             }
         }
 
-        if (clientCertificate == null) {
-            try {
-                clientCertificate = defaultCLIProperties.getClientCertificate();
-            } catch (Exception e) {
-                Logger.error(e,"Default client certificate could not be loaded ({})", Throwables.getRootCause(e).getMessage());
-            }
-        }
-
-        if (clientPrivateKey == null) {
-            try {
-                clientPrivateKey = defaultCLIProperties.getClientPrivateKey();
-            } catch (Exception e) {
-                Logger.error(e,"Default client private key could not be loaded ({})", Throwables.getRootCause(e).getMessage());
-            }
-        }
 
         if (useWebSocket && webSocketPath == null) {
             webSocketPath = defaultCLIProperties.getWebsocketPath();
         }
 
-        try {
-            final X509Certificate defaultServerCertificate = defaultCLIProperties.getServerCertificate();
-            if (defaultServerCertificate != null) {
-                if(certificates == null){
-                    certificates = new ArrayList<>();
-                }
-                certificates.add(defaultServerCertificate);
-            }
-        } catch (Exception e) {
-            Logger.error(e,"Default server certificate could not be loaded ({})", Throwables.getRootCause(e).getMessage());
-        }
-
     }
 
-
-    public @Nullable MqttClientSslConfig buildSslConfig() {
-
-        if (useBuiltSslConfig()) {
-            try {
-                return doBuildSslConfig();
-            }
-            catch (Exception e) {
-                Logger.error(e, Throwables.getRootCause(e).getMessage());
-            }
-        }
-
-        return null;
+    @Nullable
+    public MqttClientSslConfig buildSslConfig() throws Exception {
+        return sslOptions.buildSslConfig();
     }
 
-    private boolean useBuiltSslConfig() {
-        return certificates != null ||
-                certificatesFromDir != null ||
-                cipherSuites != null ||
-                supportedTLSVersions != null ||
-                clientPrivateKey != null ||
-                clientCertificate != null ||
-                useSsl;
-    }
-
-    private @NotNull MqttClientSslConfig doBuildSslConfig() throws Exception {
-
-        if (certificatesFromDir != null) {
-            if (certificates == null) {
-                certificates = certificatesFromDir;
-            }
-            else {
-                certificates.addAll(certificatesFromDir);
-            }
-        }
-
-
-        // build trustManagerFactory for server side authentication and to enable tls
-        TrustManagerFactory trustManagerFactory = null;
-        if (certificates != null && !certificates.isEmpty()) {
-            trustManagerFactory = buildTrustManagerFactory(certificates);
-        }
-
-
-        // build keyManagerFactory if clientSideAuthentication is used
-        KeyManagerFactory keyManagerFactory = null;
-        if (clientCertificate != null && clientPrivateKey != null) {
-            keyManagerFactory = buildKeyManagerFactory(clientCertificate, clientPrivateKey);
-        }
-
-        // default to tlsv.2
-        if (supportedTLSVersions == null) {
-            supportedTLSVersions = new ArrayList<>();
-            supportedTLSVersions.add(DEFAULT_TLS_VERSION);
-        }
-
-        return MqttClientSslConfig.builder()
-                .trustManagerFactory(trustManagerFactory)
-                .keyManagerFactory(keyManagerFactory)
-                .cipherSuites(cipherSuites)
-                .protocols(supportedTLSVersions)
-                .build();
-    }
-
-
-    private TrustManagerFactory buildTrustManagerFactory(final @NotNull Collection<X509Certificate> certCollection) throws Exception {
-
-        final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        ks.load(null, null);
-
-        // add all certificates of the collection to the KeyStore
-        int i = 1;
-        for (final X509Certificate cert : certCollection) {
-            final String alias = Integer.toString(i);
-            ks.setCertificateEntry(alias, cert);
-            i++;
-        }
-
-        final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-
-        trustManagerFactory.init(ks);
-
-        return trustManagerFactory;
-    }
-
-    private KeyManagerFactory buildKeyManagerFactory(final @NotNull X509Certificate cert, final @NotNull PrivateKey key) throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException, UnrecoverableKeyException {
-
-        final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-
-        ks.load(null, null);
-
-        final Certificate[] certChain = new Certificate[1];
-        certChain[0] = cert;
-        ks.setKeyEntry("mykey", key, null, certChain);
-
-        final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-
-        keyManagerFactory.init(ks, null);
-
-        return keyManagerFactory;
-    }
-
-    public boolean isUseSsl() {
-        return useSsl;
-    }
 
     @Override
     public String toString() {
@@ -278,8 +111,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
                 (user != null ? (", user=" + user) : "") +
                 (keepAlive != null ? (", keepAlive=" + keepAlive) : "") +
                 (cleanStart != null ? (", cleanStart=" + cleanStart) : "") +
-                ", useDefaultSsl=" + useSsl +
-                (getSslConfig() != null ? (", sslConfig=" + getSslConfig()) : "") +
+                ", sslOptions=" + sslOptions +
                 ", useWebSocket=" + useWebSocket +
                 (webSocketPath != null ? (", webSocketPath=" + webSocketPath) : "") +
                 getWillOptions();
@@ -315,8 +147,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
             return MqttWebSocketConfig.builder()
                     .serverPath(webSocketPath)
                     .build();
-        }
-        else {
+        } else {
             return null;
         }
     }

--- a/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
+++ b/src/main/java/com/hivemq/cli/commands/AbstractCommonFlags.java
@@ -36,12 +36,10 @@ import java.nio.ByteBuffer;
 public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlags implements Connect {
 
     @CommandLine.Option(names = {"-u", "--user"}, description = "The username for authentication", order = 2)
-    @Nullable
-    private String user;
+    private @Nullable String user;
 
     @CommandLine.Option(names = {"-pw", "--password"}, arity = "0..1", interactive = true, converter = ByteBufferConverter.class, description = "The password for authentication", order = 2)
-    @Nullable
-    private ByteBuffer password;
+    private @Nullable ByteBuffer password;
 
     @CommandLine.Option(names = {"-pw:env"}, arity = "0..1", converter = EnvVarToByteBufferConverter.class, fallbackValue = "MQTT_CLI_PW", description = "The password for authentication read in from an environment variable", order = 2)
     private void setPasswordFromEnv(final @NotNull ByteBuffer passwordEnvironmentVariable) { password = passwordEnvironmentVariable; }
@@ -53,8 +51,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
     private @Nullable Integer keepAlive;
 
     @CommandLine.Option(names = {"-c", "--cleanStart"}, negatable = true, description = "Define a clean start for the connection (default: true)", order = 2)
-    @Nullable
-    private Boolean cleanStart;
+    private @Nullable Boolean cleanStart;
 
     @CommandLine.Mixin
     private final SslOptions sslOptions = new SslOptions();
@@ -63,8 +60,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
     private boolean useWebSocket;
 
     @CommandLine.Option(names = {"-ws:path"}, description = "The path of the WebSocket", order = 2)
-    @Nullable
-    private String webSocketPath;
+    private @Nullable String webSocketPath;
 
     @Override
     public void setDefaultOptions() {
@@ -78,7 +74,7 @@ public abstract class AbstractCommonFlags extends AbstractConnectRestrictionFlag
         if (password == null) {
             try {
                 password = defaultCLIProperties.getPassword();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 Logger.error(e, "Default password could not be loaded ({})", Throwables.getRootCause(e).getMessage());
             }
         }

--- a/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
@@ -112,11 +112,16 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
 
         String logLevel = "warn";
         if (isDebug()) logLevel = "debug";
-        else if (isVerbose()) logLevel = "trace";
+        if (isVerbose()) logLevel = "trace";
         LoggerUtils.setupConsoleLogging(logToLogfile, logLevel);
 
         setDefaultOptions();
-        sslConfig = buildSslConfig();
+        try {
+            sslConfig = buildSslConfig();
+        } catch (Exception e) {
+            Logger.error(e, "Could not build SSL configuration");
+            return;
+        }
 
         Logger.trace("Command {} ", this);
 

--- a/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
@@ -118,7 +118,7 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
         setDefaultOptions();
         try {
             sslConfig = buildSslConfig();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Logger.error(e, "Could not build SSL configuration");
             return;
         }

--- a/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
@@ -111,11 +111,16 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
 
         String logLevel = "warn";
         if (isDebug()) logLevel = "debug";
-        else if (isVerbose()) logLevel = "trace";
+        if (isVerbose()) logLevel = "trace";
         LoggerUtils.setupConsoleLogging(logToLogfile, logLevel);
 
         setDefaultOptions();
-        sslConfig = buildSslConfig();
+        try {
+            sslConfig = buildSslConfig();
+        } catch (Exception e) {
+            Logger.error(e, "Could not build SSL configuration");
+            return;
+        }
 
         Logger.trace("Command {} ", this);
 

--- a/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/SubscribeCommand.java
@@ -117,7 +117,7 @@ public class SubscribeCommand extends AbstractConnectFlags implements MqttAction
         setDefaultOptions();
         try {
             sslConfig = buildSslConfig();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Logger.error(e, "Could not build SSL configuration");
             return;
         }

--- a/src/main/java/com/hivemq/cli/commands/options/SslOptions.java
+++ b/src/main/java/com/hivemq/cli/commands/options/SslOptions.java
@@ -182,15 +182,16 @@ public class SslOptions {
 
     private KeyManagerFactory buildKeyManagerFactory(final @NotNull X509Certificate[] certs, final @NotNull PrivateKey key) throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException, UnrecoverableKeyException {
 
+        final String password = "PA$$WORD";
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
 
         ks.load(null, null);
 
-        ks.setKeyEntry("mykey", key, null, certs);
+        ks.setKeyEntry("mykey", key, password.toCharArray(), certs);
 
         final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 
-        keyManagerFactory.init(ks, null);
+        keyManagerFactory.init(ks, password.toCharArray());
 
         return keyManagerFactory;
     }

--- a/src/main/java/com/hivemq/cli/commands/options/SslOptions.java
+++ b/src/main/java/com/hivemq/cli/commands/options/SslOptions.java
@@ -16,12 +16,16 @@
  */
 package com.hivemq.cli.commands.options;
 
-import com.hivemq.cli.converters.DirectoryToCertificateCollectionConverter;
-import com.hivemq.cli.converters.FileToCertificateConverter;
+import com.google.common.base.Throwables;
+import com.hivemq.cli.DefaultCLIProperties;
+import com.hivemq.cli.MqttCLIMain;
+import com.hivemq.cli.converters.DirectoryToCertificatesConverter;
+import com.hivemq.cli.converters.FileToCertificatesConverter;
 import com.hivemq.cli.converters.FileToPrivateKeyConverter;
 import com.hivemq.client.mqtt.MqttClientSslConfig;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.tinylog.Logger;
 import picocli.CommandLine;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -32,7 +36,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -45,13 +48,13 @@ public class SslOptions {
     @CommandLine.Option(names = {"-s", "--secure"}, defaultValue = "false", description = "Use default ssl configuration if no other ssl options are specified (default: false)", order = 2)
     private boolean useSsl;
 
-    @CommandLine.Option(names = {"--cafile"}, paramLabel = "FILE", converter = FileToCertificateConverter.class, description = "Path to a file containing trusted CA certificates to enable encrypted certificate based communication", order = 2)
+    @CommandLine.Option(names = {"--cafile"}, paramLabel = "FILE", converter = FileToCertificatesConverter.class, description = "Path to a file containing trusted CA certificates to enable encrypted certificate based communication", order = 2)
     @Nullable
-    private Collection<X509Certificate> certificates;
+    private Collection<X509Certificate> serverCertificateChain;
 
-    @CommandLine.Option(names = {"--capath"}, paramLabel = "DIR", converter = DirectoryToCertificateCollectionConverter.class, description = {"Path to a directory containing certificate files to import to enable encrypted certificate based communication"}, order = 2)
+    @CommandLine.Option(names = {"--capath"}, paramLabel = "DIR", converter = DirectoryToCertificatesConverter.class, description = {"Path to a directory containing certificate files to import to enable encrypted certificate based communication"}, order = 2)
     @Nullable
-    private Collection<X509Certificate> certificatesFromDir;
+    private Collection<X509Certificate> serverCertificateChainFromDir;
 
     @CommandLine.Option(names = {"--ciphers"}, split = ":", description = "The client supported cipher suites list in IANA format separated with ':'", order = 2)
     @Nullable
@@ -61,51 +64,53 @@ public class SslOptions {
     @Nullable
     private Collection<String> supportedTLSVersions;
 
-    @CommandLine.Option(names = {"--cert"}, converter = FileToCertificateConverter.class, description = "The client certificate to use for client side authentication", order = 2)
+    @CommandLine.Option(names = {"--cert"}, converter = FileToCertificatesConverter.class, description = "The client certificate to use for client side authentication", order = 2)
     @Nullable
-    private X509Certificate clientCertificate;
+    private Collection<X509Certificate> clientCertificateChain;
 
     @CommandLine.Option(names = {"--key"}, converter = FileToPrivateKeyConverter.class, description = "The path to the client private key for client side authentication", order = 2)
     @Nullable
     private PrivateKey clientPrivateKey;
 
     private boolean useBuiltSslConfig() {
-        return certificates != null ||
-                certificatesFromDir != null ||
+        return serverCertificateChain != null ||
+                serverCertificateChainFromDir != null ||
                 cipherSuites != null ||
                 supportedTLSVersions != null ||
                 clientPrivateKey != null ||
-                clientCertificate != null ||
+                clientCertificateChain != null ||
                 useSsl;
     }
 
     public @Nullable MqttClientSslConfig buildSslConfig() throws Exception {
 
+        setDefaultOptions();
+
         if (!useBuiltSslConfig()) {
             return null;
         }
 
-        if (certificatesFromDir != null) {
-            if (certificates == null) {
-                certificates = certificatesFromDir;
+        if (serverCertificateChainFromDir != null) {
+            if (serverCertificateChain == null) {
+                serverCertificateChain = serverCertificateChainFromDir;
             }
             else {
-                certificates.addAll(certificatesFromDir);
+                serverCertificateChain.addAll(serverCertificateChainFromDir);
             }
         }
 
 
         // build trustManagerFactory for server side authentication and to enable tls
         TrustManagerFactory trustManagerFactory = null;
-        if (certificates != null && !certificates.isEmpty()) {
-            trustManagerFactory = buildTrustManagerFactory(certificates);
+        if (serverCertificateChain != null && !serverCertificateChain.isEmpty()) {
+            trustManagerFactory = buildTrustManagerFactory(serverCertificateChain);
         }
 
 
         // build keyManagerFactory if clientSideAuthentication is used
         KeyManagerFactory keyManagerFactory = null;
-        if (clientCertificate != null && clientPrivateKey != null) {
-            keyManagerFactory = buildKeyManagerFactory(clientCertificate, clientPrivateKey);
+        if (clientCertificateChain != null && clientPrivateKey != null) {
+            keyManagerFactory = buildKeyManagerFactory(clientCertificateChain.toArray(new X509Certificate[0]), clientPrivateKey);
         }
 
         // default to tlsv.2
@@ -120,6 +125,38 @@ public class SslOptions {
                 .cipherSuites(cipherSuites)
                 .protocols(supportedTLSVersions)
                 .build();
+    }
+
+    private void setDefaultOptions() {
+        final DefaultCLIProperties defaultCLIProperties = MqttCLIMain.MQTTCLI.defaultCLIProperties();
+
+        if (clientCertificateChain == null) {
+            try {
+                clientCertificateChain = defaultCLIProperties.getClientCertificateChain();
+            } catch (Exception e) {
+                Logger.error(e,"Default client certificate chain could not be loaded ({})", Throwables.getRootCause(e).getMessage());
+            }
+        }
+
+        if (clientPrivateKey == null) {
+            try {
+                clientPrivateKey = defaultCLIProperties.getClientPrivateKey();
+            } catch (Exception e) {
+                Logger.error(e,"Default client private key could not be loaded ({})", Throwables.getRootCause(e).getMessage());
+            }
+        }
+
+        try {
+            final Collection<X509Certificate> defaultServerCertificate = defaultCLIProperties.getServerCertificateChain();
+            if (defaultServerCertificate != null) {
+                if(serverCertificateChain == null){
+                    serverCertificateChain = new ArrayList<>();
+                }
+                serverCertificateChain.addAll(defaultServerCertificate);
+            }
+        } catch (Exception e) {
+            Logger.error(e,"Default server certificate could not be loaded ({})", Throwables.getRootCause(e).getMessage());
+        }
     }
 
 
@@ -143,15 +180,13 @@ public class SslOptions {
         return trustManagerFactory;
     }
 
-    private KeyManagerFactory buildKeyManagerFactory(final @NotNull X509Certificate cert, final @NotNull PrivateKey key) throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException, UnrecoverableKeyException {
+    private KeyManagerFactory buildKeyManagerFactory(final @NotNull X509Certificate[] certs, final @NotNull PrivateKey key) throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException, UnrecoverableKeyException {
 
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
 
         ks.load(null, null);
 
-        final Certificate[] certChain = new Certificate[1];
-        certChain[0] = cert;
-        ks.setKeyEntry("mykey", key, null, certChain);
+        ks.setKeyEntry("mykey", key, null, certs);
 
         final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 
@@ -164,11 +199,11 @@ public class SslOptions {
     public String toString() {
         return "SslOptions{" +
                 "useSsl=" + useSsl +
-                ", certificates=" + certificates +
-                ", certificatesFromDir=" + certificatesFromDir +
+                ", serverCertificates=" + serverCertificateChain +
+                ", serverCertificatesFromDir=" + serverCertificateChainFromDir +
                 ", cipherSuites=" + cipherSuites +
                 ", supportedTLSVersions=" + supportedTLSVersions +
-                ", clientCertificate=" + clientCertificate +
+                ", clientCertificates=" + clientCertificateChain +
                 ", clientPrivateKey=" + clientPrivateKey +
                 '}';
     }
@@ -177,15 +212,15 @@ public class SslOptions {
         return useSsl;
     }
 
-    public @Nullable Collection<X509Certificate> getCertificates() { return certificates; }
+    public @Nullable Collection<X509Certificate> getServerCertificateChain() { return serverCertificateChain; }
 
-    public @Nullable Collection<X509Certificate> getCertificatesFromDir() { return certificatesFromDir; }
+    public @Nullable Collection<X509Certificate> getServerCertificateChainFromDir() { return serverCertificateChainFromDir; }
 
     public @Nullable Collection<String> getCipherSuites() { return cipherSuites; }
 
     public @Nullable Collection<String> getSupportedTLSVersions() { return supportedTLSVersions; }
 
-    public @Nullable X509Certificate getClientCertificate() { return clientCertificate; }
+    public @Nullable Collection<X509Certificate> getClientCertificateChain() { return clientCertificateChain; }
 
     public @Nullable PrivateKey getClientPrivateKey() { return clientPrivateKey; }
 }

--- a/src/main/java/com/hivemq/cli/commands/options/SslOptions.java
+++ b/src/main/java/com/hivemq/cli/commands/options/SslOptions.java
@@ -133,7 +133,7 @@ public class SslOptions {
         if (clientCertificateChain == null) {
             try {
                 clientCertificateChain = defaultCLIProperties.getClientCertificateChain();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 Logger.error(e,"Default client certificate chain could not be loaded ({})", Throwables.getRootCause(e).getMessage());
             }
         }
@@ -141,7 +141,7 @@ public class SslOptions {
         if (clientPrivateKey == null) {
             try {
                 clientPrivateKey = defaultCLIProperties.getClientPrivateKey();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 Logger.error(e,"Default client private key could not be loaded ({})", Throwables.getRootCause(e).getMessage());
             }
         }
@@ -154,7 +154,7 @@ public class SslOptions {
                 }
                 serverCertificateChain.addAll(defaultServerCertificate);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Logger.error(e,"Default server certificate could not be loaded ({})", Throwables.getRootCause(e).getMessage());
         }
     }

--- a/src/main/java/com/hivemq/cli/commands/shell/ShellConnectCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ShellConnectCommand.java
@@ -68,9 +68,17 @@ public class ShellConnectCommand extends AbstractCommonFlags implements Runnable
 
     public void run() {
         setDefaultOptions();
-        sslConfig = buildSslConfig();
+
+        try {
+            sslConfig = buildSslConfig();
+        } catch (Exception e) {
+            Logger.error(e, "Could not build SSL configuration");
+            return;
+        }
+
         logUnusedOptions();
         final MqttClient client = connect();
+
         sslConfig = null;
         ShellContextCommand.updateContext(client);
     }

--- a/src/main/java/com/hivemq/cli/commands/shell/ShellConnectCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ShellConnectCommand.java
@@ -71,7 +71,7 @@ public class ShellConnectCommand extends AbstractCommonFlags implements Runnable
 
         try {
             sslConfig = buildSslConfig();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Logger.error(e, "Could not build SSL configuration");
             return;
         }

--- a/src/main/java/com/hivemq/cli/converters/DirectoryToCertificatesConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/DirectoryToCertificatesConverter.java
@@ -26,12 +26,13 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class DirectoryToCertificateCollectionConverter implements CommandLine.ITypeConverter<Collection<X509Certificate>> {
+public class DirectoryToCertificatesConverter implements CommandLine.ITypeConverter<Collection<X509Certificate>> {
     static final String DIRECTORY_NOT_FOUND = "The given directory was not found.";
     static final String NOT_A_DIRECTORY = "The given path is not a valid directory";
     static final String NO_CERTIFICATES_FOUND_IN_DIRECTORY = "The given directory does not contain any valid certificates";
 
     @Override
+    @NotNull
     public Collection<X509Certificate> convert(final @NotNull String s) throws Exception {
 
         final File directory = new File(s);
@@ -50,7 +51,7 @@ public class DirectoryToCertificateCollectionConverter implements CommandLine.IT
         final Collection<X509Certificate> certificates = new ArrayList<>();
 
         for (final File validFile : validFiles) {
-            certificates.add(CertificateConverterUtils.generateX509Certificate(validFile));
+            certificates.addAll(CertificateConverterUtils.generateX509Certificates(validFile));
         }
 
         return certificates;

--- a/src/main/java/com/hivemq/cli/converters/DirectoryToCertificatesConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/DirectoryToCertificatesConverter.java
@@ -32,8 +32,7 @@ public class DirectoryToCertificatesConverter implements CommandLine.ITypeConver
     static final String NO_CERTIFICATES_FOUND_IN_DIRECTORY = "The given directory does not contain any valid certificates";
 
     @Override
-    @NotNull
-    public Collection<X509Certificate> convert(final @NotNull String s) throws Exception {
+    public @NotNull Collection<X509Certificate> convert(final @NotNull String s) throws Exception {
 
         final File directory = new File(s);
 

--- a/src/main/java/com/hivemq/cli/converters/FileToCertificatesConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToCertificatesConverter.java
@@ -31,8 +31,7 @@ public class FileToCertificatesConverter implements CommandLine.ITypeConverter<C
     static final String NO_VALID_FILE_EXTENSION = "The given file does not conform to a valid Certificate File Extension as " + Arrays.toString(CertificateConverterUtils.FILE_EXTENSIONS);
 
     @Override
-    @NotNull
-    public Collection<X509Certificate> convert(final @NotNull String s) throws Exception {
+    public @NotNull Collection<X509Certificate> convert(final @NotNull String s) throws Exception {
 
         FileConverter fileConverter = new FileConverter();
         final File keyFile = fileConverter.convert(s);

--- a/src/main/java/com/hivemq/cli/converters/FileToCertificatesConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToCertificatesConverter.java
@@ -21,15 +21,18 @@ import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine;
 
 import java.io.File;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collection;
 
-public class FileToCertificateConverter implements CommandLine.ITypeConverter<X509Certificate> {
+public class FileToCertificatesConverter implements CommandLine.ITypeConverter<Collection<? extends Certificate>> {
 
     static final String NO_VALID_FILE_EXTENSION = "The given file does not conform to a valid Certificate File Extension as " + Arrays.toString(CertificateConverterUtils.FILE_EXTENSIONS);
 
     @Override
-    public X509Certificate convert(final @NotNull String s) throws Exception {
+    @NotNull
+    public Collection<X509Certificate> convert(final @NotNull String s) throws Exception {
 
         FileConverter fileConverter = new FileConverter();
         final File keyFile = fileConverter.convert(s);
@@ -39,7 +42,7 @@ public class FileToCertificateConverter implements CommandLine.ITypeConverter<X5
         if (!correctExtension)
             throw new IllegalArgumentException(NO_VALID_FILE_EXTENSION);
 
-        return CertificateConverterUtils.generateX509Certificate(keyFile);
+        return CertificateConverterUtils.generateX509Certificates(keyFile);
 
     }
 

--- a/src/main/java/com/hivemq/cli/utils/CertificateConverterUtils.java
+++ b/src/main/java/com/hivemq/cli/utils/CertificateConverterUtils.java
@@ -21,18 +21,29 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 
 public class CertificateConverterUtils {
     public static final String[] FILE_EXTENSIONS = {".pem", ".cer", ".crt"};
     public static final String NO_VALID_CERTIFICATE = "The given file contains no valid or supported certficate,";
 
-    public static X509Certificate generateX509Certificate(final @NotNull File keyFile) throws Exception {
+    @NotNull
+    public static Collection<X509Certificate> generateX509Certificates(final @NotNull File keyFile) throws Exception {
+
+        // Instantiate X509 certificate factory
         final CertificateFactory cf = CertificateFactory.getInstance("X.509");
         try {
-            return (X509Certificate) cf.generateCertificate(new FileInputStream(keyFile));
+
+            // Parse X509 certificate chain
+            final Collection<? extends Certificate> certificateChainCollection = cf.generateCertificates(new FileInputStream(keyFile));
+
+            // Cast to X509Certificate collection and return it
+            return (Collection<X509Certificate>) certificateChainCollection;
+
         } catch (CertificateException | FileNotFoundException ce) {
             throw new CertificateException(NO_VALID_CERTIFICATE);
         }

--- a/src/main/java/com/hivemq/cli/utils/CertificateConverterUtils.java
+++ b/src/main/java/com/hivemq/cli/utils/CertificateConverterUtils.java
@@ -31,8 +31,7 @@ public class CertificateConverterUtils {
     public static final String[] FILE_EXTENSIONS = {".pem", ".cer", ".crt"};
     public static final String NO_VALID_CERTIFICATE = "The given file contains no valid or supported certficate,";
 
-    @NotNull
-    public static Collection<X509Certificate> generateX509Certificates(final @NotNull File keyFile) throws Exception {
+    public static @NotNull Collection<X509Certificate> generateX509Certificates(final @NotNull File keyFile) throws Exception {
 
         // Instantiate X509 certificate factory
         final CertificateFactory cf = CertificateFactory.getInstance("X.509");

--- a/src/test/java/com/hivemq/cli/DefaultCLIPropertiesTest.java
+++ b/src/test/java/com/hivemq/cli/DefaultCLIPropertiesTest.java
@@ -77,8 +77,8 @@ class DefaultCLIPropertiesTest {
         assertNull(defaultCLIProperties.getClientSubscribeOutputFile());
         assertNull(defaultCLIProperties.getUsername());
         assertNull(defaultCLIProperties.getPassword());
-        assertNull(defaultCLIProperties.getClientCertificate());
-        assertNull(defaultCLIProperties.getServerCertificate());
+        assertNull(defaultCLIProperties.getClientCertificateChain());
+        assertNull(defaultCLIProperties.getServerCertificateChain());
         assertNull(defaultCLIProperties.getClientPrivateKey());
     }
 
@@ -96,8 +96,8 @@ class DefaultCLIPropertiesTest {
         assertNull(defaultCLIProperties.getClientSubscribeOutputFile());
         assertNull(defaultCLIProperties.getUsername());
         assertNull(defaultCLIProperties.getPassword());
-        assertNull(defaultCLIProperties.getClientCertificate());
-        assertNull(defaultCLIProperties.getServerCertificate());
+        assertNull(defaultCLIProperties.getClientCertificateChain());
+        assertNull(defaultCLIProperties.getServerCertificateChain());
         assertNull(defaultCLIProperties.getClientPrivateKey());
     }
 
@@ -115,8 +115,8 @@ class DefaultCLIPropertiesTest {
         assertNull(defaultCLIProperties.getClientSubscribeOutputFile());
         assertEquals("mqtt" , defaultCLIProperties.getUsername());
         assertEquals(ByteBuffer.wrap("password".getBytes()), defaultCLIProperties.getPassword());
-        assertNull(defaultCLIProperties.getClientCertificate());
-        assertNull(defaultCLIProperties.getServerCertificate());
+        assertNull(defaultCLIProperties.getClientCertificateChain());
+        assertNull(defaultCLIProperties.getServerCertificateChain());
         assertNull(defaultCLIProperties.getClientPrivateKey());
     }
 

--- a/src/test/java/com/hivemq/cli/converters/CertificateConverterUtilsTest.java
+++ b/src/test/java/com/hivemq/cli/converters/CertificateConverterUtilsTest.java
@@ -27,10 +27,10 @@ import java.io.File;
 import java.net.URL;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,13 +53,14 @@ class CertificateConverterUtilsTest {
 
     @Test
     void generateX509Certificate_Success() throws Exception {
-        X509Certificate cert = CertificateConverterUtils.generateX509Certificate(new File(pathToValidCertficate));
-        assertNotNull(cert);
+        final Collection<X509Certificate> x509Certificates = CertificateConverterUtils.generateX509Certificates(new File(pathToValidCertficate));
+
+        assertEquals(1, x509Certificates.size());
     }
 
     @Test
     void generateX509Certificate_Failure() {
-        Exception e = assertThrows(CertificateException.class, () -> CertificateConverterUtils.generateX509Certificate(new File(pathToInvalidCertificate)));
+        Exception e = assertThrows(CertificateException.class, () -> CertificateConverterUtils.generateX509Certificates(new File(pathToInvalidCertificate)));
         assertEquals(CertificateConverterUtils.NO_VALID_CERTIFICATE, e.getMessage());
     }
 

--- a/src/test/java/com/hivemq/cli/converters/DirectoryToCertificatesConverterTest.java
+++ b/src/test/java/com/hivemq/cli/converters/DirectoryToCertificatesConverterTest.java
@@ -28,15 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class DirectoryToCertificateCollectionConverterTest {
-    private DirectoryToCertificateCollectionConverter directoryToCertificateCollectionConverter;
+class DirectoryToCertificatesConverterTest {
+    private DirectoryToCertificatesConverter directoryToCertificatesConverter;
     private String pathToValidDirectory;
     private String pathToValidCertificate;
     private String pathToDirectoryWithoutCertificates;
 
     @BeforeEach
     void setUp() {
-        directoryToCertificateCollectionConverter = new DirectoryToCertificateCollectionConverter();
+        directoryToCertificatesConverter = new DirectoryToCertificatesConverter();
         final URL validCertificateDirResource = getClass().getClassLoader().getResource("FileToCertificateConverter/directory_with_certificates");
         final URL noCertificatesDir = getClass().getClassLoader().getResource("FileToCertificateConverter/directory_without_certificates");
         final URL validCertificateResource = getClass().getClassLoader().getResource("FileToCertificateConverter/validCertificate.pem");
@@ -52,27 +52,27 @@ class DirectoryToCertificateCollectionConverterTest {
 
     @Test
     void convert_Success() throws Exception {
-        Collection<X509Certificate> certificates = directoryToCertificateCollectionConverter.convert(pathToValidDirectory);
+        Collection<X509Certificate> certificates = directoryToCertificatesConverter.convert(pathToValidDirectory);
         assertNotNull(certificates);
         assertEquals(3, certificates.size());
     }
 
     @Test
     void convert_Failure_DirectoryNotFound() {
-        Exception e = assertThrows(FileNotFoundException.class, () -> directoryToCertificateCollectionConverter.convert("invalidPath"));
-        assertEquals(DirectoryToCertificateCollectionConverter.DIRECTORY_NOT_FOUND, e.getMessage());
+        Exception e = assertThrows(FileNotFoundException.class, () -> directoryToCertificatesConverter.convert("invalidPath"));
+        assertEquals(DirectoryToCertificatesConverter.DIRECTORY_NOT_FOUND, e.getMessage());
     }
 
     @Test
     void convert_Failure_DirectoryIsAFile() {
-        Exception e = assertThrows(Exception.class, () -> directoryToCertificateCollectionConverter.convert(pathToValidCertificate));
-        assertEquals(DirectoryToCertificateCollectionConverter.NOT_A_DIRECTORY, e.getMessage());
+        Exception e = assertThrows(Exception.class, () -> directoryToCertificatesConverter.convert(pathToValidCertificate));
+        assertEquals(DirectoryToCertificatesConverter.NOT_A_DIRECTORY, e.getMessage());
     }
 
 
     @Test
     void convert_Failure_DirectoryWithoutCertificates() {
-        Exception e = assertThrows(Exception.class, () -> directoryToCertificateCollectionConverter.convert(pathToDirectoryWithoutCertificates));
-        assertEquals(DirectoryToCertificateCollectionConverter.NO_CERTIFICATES_FOUND_IN_DIRECTORY, e.getMessage());
+        Exception e = assertThrows(Exception.class, () -> directoryToCertificatesConverter.convert(pathToDirectoryWithoutCertificates));
+        assertEquals(DirectoryToCertificatesConverter.NO_CERTIFICATES_FOUND_IN_DIRECTORY, e.getMessage());
     }
 }

--- a/src/test/java/com/hivemq/cli/converters/FileToCertificatesConverterTest.java
+++ b/src/test/java/com/hivemq/cli/converters/FileToCertificatesConverterTest.java
@@ -23,13 +23,14 @@ import org.junit.jupiter.api.Test;
 import java.io.FileNotFoundException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class FileToCertificateConverterTest {
+class FileToCertificatesConverterTest {
 
-    private FileToCertificateConverter fileToCertificateConverter;
+    private FileToCertificatesConverter fileToCertificatesConverter;
     private String pathToValidCertificate;
     private String pathToInvalidFileExtensionCertificate;
     private String pathToNoFileExtensionCertificate;
@@ -37,7 +38,7 @@ class FileToCertificateConverterTest {
 
     @BeforeEach
     void setUp() {
-        fileToCertificateConverter = new FileToCertificateConverter();
+        fileToCertificatesConverter = new FileToCertificatesConverter();
         final URL validCertificateResource = getClass().getClassLoader().getResource("FileToCertificateConverter/validCertificate.pem");
         final URL invalidFileExtensionResource = getClass().getClassLoader().getResource("FileToCertificateConverter/invalidFileExtensionCertificate.der");
         final URL noFileExtensionCertificate = getClass().getClassLoader().getResource("FileToCertificateConverter/noFileExtensionCertificate");
@@ -56,30 +57,32 @@ class FileToCertificateConverterTest {
 
     @Test
     void convertSuccess() throws Exception {
-        X509Certificate cert = fileToCertificateConverter.convert(pathToValidCertificate);
+        final Collection<X509Certificate> x509Certificates = fileToCertificatesConverter.convert(pathToValidCertificate);
+
+        assertEquals(1, x509Certificates.size());
     }
 
     @Test
     void convert_FileNotFound() {
-        Exception e = assertThrows(FileNotFoundException.class, () -> fileToCertificateConverter.convert("wrongPathXYZ.pem"));
+        Exception e = assertThrows(FileNotFoundException.class, () -> fileToCertificatesConverter.convert("wrongPathXYZ.pem"));
         assertEquals(FileConverter.FILE_NOT_FOUND, e.getMessage());
     }
 
     @Test
     void convert_InvalidFileExtensionCertificate() {
-        Exception e = assertThrows(Exception.class, () -> fileToCertificateConverter.convert(pathToInvalidFileExtensionCertificate));
-        assertEquals(FileToCertificateConverter.NO_VALID_FILE_EXTENSION, e.getMessage());
+        Exception e = assertThrows(Exception.class, () -> fileToCertificatesConverter.convert(pathToInvalidFileExtensionCertificate));
+        assertEquals(FileToCertificatesConverter.NO_VALID_FILE_EXTENSION, e.getMessage());
     }
 
     @Test
     void convert_NoFileExtensionCertificate() {
-        Exception e = assertThrows(Exception.class, () -> fileToCertificateConverter.convert(pathToNoFileExtensionCertificate));
-        assertEquals(FileToCertificateConverter.NO_VALID_FILE_EXTENSION, e.getMessage());
+        Exception e = assertThrows(Exception.class, () -> fileToCertificatesConverter.convert(pathToNoFileExtensionCertificate));
+        assertEquals(FileToCertificatesConverter.NO_VALID_FILE_EXTENSION, e.getMessage());
     }
 
     @Test
     void convert_InvalidCertificate() {
-        Exception e = assertThrows(Exception.class, () -> fileToCertificateConverter.convert(pathToInvalidCertificate));
+        Exception e = assertThrows(Exception.class, () -> fileToCertificatesConverter.convert(pathToInvalidCertificate));
         assertEquals(CertificateConverterUtils.NO_VALID_CERTIFICATE, e.getMessage());
     }
 }


### PR DESCRIPTION
**Motivation**
Fix #132 
Fix #192 

`--cert`, `--cafile`, `--capath`  now should work correctly when certificate chains are used

**TODO**
- [ ] Fix `Could not build SSL config - password can't be null` for Java 8

**Changes**
- `FileToCertificatesConverter` now returns all certificates from a file to correctly recognize certificates chains
- Refactor`ShellConnectCommand`, `PublishCommand` and `SubscribeCommand` to use `SslOptions`
- Fixed Log level in `PublishCommand` and `SubscribeCommand` to correctly recognize `-v` option