### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:buster
+WORKDIR /usr/app
+COPY . .
+RUN ./gradlew buildDebianPackage
+
+FROM openjdk:slim
+WORKDIR /usr/app
+
+# strip the version because wildcards to not work with -jar
+COPY --from=0 /usr/app/build/libs/mqtt-cli-*.jar mqtt-cli.jar
+
+ENTRYPOINT [ "java", "-jar", "/usr/app/mqtt-cli.jar" ]
+CMD [ "shell" ]


### PR DESCRIPTION
Signed-off-by: Felix Breuer <fbreuer@pm.me>

**Motivation**  
There are Operating Systems (like NixOS) with no provided Packages. Docker removes the urge to compile from source.

**Changes**  
Dockerized the application

**Note**  
I had to strip the version in the copy step, because java does not expand a wildcard in the `-jar` Parameter. To use the Shell expand, you would have to call java with `sh -c "java ..."` but then you cannot add a custom `CMD`. Haven't found a cleaner solution yet.

I use the `buildDebianPackage` Task even though i only need to build the jar File. I am not familiar with Gradle but a new Task to only produce the jar File would be the better fit. (Maybe) we do not need to use the buster version in the build step then.

**Further work**  
Push the image to Dockerhub / create a simple Dockerhub webhook for automated builds.