### PR TITLE
Add java headless as a valid deb dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -454,7 +454,7 @@ ospackage {
 }
 
 tasks.buildDeb {
-    requires("default-jre").or("java8-runtime")
+    requires("default-jre").or("java8-runtime").or("java8-runtime-headless")
 }
 
 tasks.buildRpm {


### PR DESCRIPTION
For systems that have a headless version of the jre installed such as `openjdk-8-jre-headless`

**Motivation**
Allow installation of deb package in systems with a headless jre

**Changes**
Add extra dependency option