### PR TITLE
Send file content as message payload.

### DIFF
--- a/docs/_docs/publish.md
+++ b/docs/_docs/publish.md
@@ -10,11 +10,12 @@ Publishes a message to one or more topics.
 ## Simple Examples   
 
 
-|Command                                                |Explanation                                                              |
-|-------------------------------------------------------|-------------------------------------------------------------------------|
-| ``mqtt pub -t test -m "Hello" `` | Publish the message ``Hello`` with topic 'topic' using the default settings
-| ``mqtt pub -t test1 -t test2 -m "Hello Tests"`` | Publish the message ``Hello Tests`` with topics 'test1' and 'test2'
-| ``mqtt pub -t test -m "Hello" -h localhost -p 1884``| Publish the message ``Hello`` with topic 'topic' to a broker at localhost:1884|
+| Command                                              |Explanation                                                              |
+|------------------------------------------------------|-------------------------------------------------------------------------|
+| ``mqtt pub -t test -m "Hello" ``                     | Publish the message ``Hello`` with topic 'topic' using the default settings
+| ``mqtt pub -t test1 -t test2 -m "Hello Tests"``      | Publish the message ``Hello Tests`` with topics 'test1' and 'test2'
+| ``mqtt pub -t test -m "Hello" -h localhost -p 1884`` | Publish the message ``Hello`` with topic 'topic' to a broker at localhost:1884|
+| ``mqtt pub -t test -m:file payload.txt``             | Publish the message in payload.txt with topic 'topic' using the default settings
 
 <!---
 See also 
@@ -29,7 +30,7 @@ mqtt pub --help
 
 ``` 
 mqtt pub    -t <topics> [-t <topics>]... 
-            -m <message> 
+            (-m <message> | -m:file <filename>)
             [-cdrsvl] 
             [-q <qos>]...
             [-e <messageExpiryInterval>]          
@@ -85,21 +86,22 @@ mqtt pub    -t <topics> [-t <topics>]...
 
 ## Publish options
 
-|Option   |Long Version    | Explanation                                         | Default|
-|---------|----------------|-----------------------------------------------------|---------|
-| ``-t``   | ``--topic``| The MQTT topic to which the message will be published. |
-| ``-m``| ``--message`` | The message which will be published on the topic. |
-| ``-r``| ``--[no-]retain`` | Whether the message will be retained. | ``False``
-| ``-q`` | ``--qos`` | Define the quality of service level. If only one QoS is specified it will be used for all topics.<br> You can define a specific QoS level for every topic. The corresponding QoS levels will be matched in order to the given topics. | ``0``
-| ``-e`` | ``--messageExpiryInterval`` | The lifetime of the publish message in seconds. |
-| ``-ct`` | ``--contentType`` | A description of the content of the publish message. |
-| ``-cd`` | ``--correlationData`` | The correlation data of the publish message. |
-| ``-pf`` | ``--payloadFormatIndicator`` | The payload format indicator of the publish message. |
-| ``-rt`` | ``--responseTopic`` | The topic name for the response message of the publish message. |
-| ``-up`` | ``--userProperty``  | A user property of the publish message |
-| ``-d``    |   ``--debug``     | Print debug level messages to the console. | ``False``
-| ``-v``    |   ``--verbose``   | Print trace level messages to the console. | ``False``
-| ``-l`` | | Log to ~./mqtt.cli/logs (Configurable through ~/.mqtt-cli/config.properties) | ``false``
+| Option      | Long Version                 | Explanation                                                                                                                                                                                                                           | Default|
+|-------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| ``-t``      | ``--topic``                  | The MQTT topic to which the message will be published.                                                                                                                                                                                |
+| ``-m``      | ``--message``                | The message which will be published on the topic.                                                                                                                                                                                     |
+| ``-m:file`` | ``--message-file``           | The file whose payload will be published on the topic.                                                                                                                                                                                |
+| ``-r``      | ``--[no-]retain``            | Whether the message will be retained.                                                                                                                                                                                                 | ``False``
+| ``-q``      | ``--qos``                    | Define the quality of service level. If only one QoS is specified it will be used for all topics.<br> You can define a specific QoS level for every topic. The corresponding QoS levels will be matched in order to the given topics. | ``0``
+| ``-e``      | ``--messageExpiryInterval``  | The lifetime of the publish message in seconds.                                                                                                                                                                                       |
+| ``-ct``     | ``--contentType``            | A description of the content of the publish message.                                                                                                                                                                                  |
+| ``-cd``     | ``--correlationData``        | The correlation data of the publish message.                                                                                                                                                                                          |
+| ``-pf``     | ``--payloadFormatIndicator`` | The payload format indicator of the publish message.                                                                                                                                                                                  |
+| ``-rt``     | ``--responseTopic``          | The topic name for the response message of the publish message.                                                                                                                                                                       |
+| ``-up``     | ``--userProperty``           | A user property of the publish message                                                                                                                                                                                                |
+| ``-d``      | ``--debug``                  | Print debug level messages to the console.                                                                                                                                                                                            | ``False``
+| ``-v``      | ``--verbose``                | Print trace level messages to the console.                                                                                                                                                                                            | ``False``
+| ``-l``      |                              | Log to ~./mqtt.cli/logs (Configurable through ~/.mqtt-cli/config.properties)                                                                                                                                                          | ``false``
 
 ***
 

--- a/docs/_docs/shell/publish.md
+++ b/docs/_docs/shell/publish.md
@@ -13,7 +13,7 @@ Instead it uses the currently active context client.
 
 ```
 client@host> pub    -t <topics> [-t <topics>]... 
-                    -m <message> 
+                    (-m <message> | -m:file <filename>)
                     [-q <qos>]... 
                     [-r]
                     [-e <messageExpiryInterval>] 
@@ -33,6 +33,7 @@ client@host> pub    -t <topics> [-t <topics>]...
 |---------|----------------|-----------------------------------------------------|---------|
 | ``-t``   | ``--topic``| The MQTT topic where the message will be published. |
 | ``-m``| ``--message`` | The message which will be published on the topic. |
+| ``-m:file`` | ``--message-file``           | The file whose payload will be published on the topic.                                                                                                                                                                                |
 | ``-q`` | ``--qos`` | Use a defined quality of service level on all topics if only one QoS is specified.<br> You can define a specific QoS level for every topic. The corresponding QoS levels will be matched in order to the given topics. | ``0``
 | ``-r``| ``--[no-]retain`` | Message will be retained. | ``False``
 | ``-e`` | ``--messageExpiryInterval`` | The lifetime of the publish message in seconds. |

--- a/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/PublishCommand.java
@@ -18,11 +18,8 @@ package com.hivemq.cli.commands.cli;
 import com.google.common.base.Throwables;
 import com.hivemq.cli.MqttCLIMain;
 import com.hivemq.cli.commands.Publish;
-import com.hivemq.cli.converters.ByteBufferConverter;
-import com.hivemq.cli.converters.Mqtt5UserPropertyConverter;
-import com.hivemq.cli.converters.MqttQosConverter;
-import com.hivemq.cli.converters.PayloadFormatIndicatorConverter;
-import com.hivemq.cli.converters.UnsignedIntConverter;
+import com.hivemq.cli.commands.options.MessagePayloadOptions;
+import com.hivemq.cli.converters.*;
 import com.hivemq.cli.impl.MqttAction;
 import com.hivemq.cli.mqtt.MqttClientExecutor;
 import com.hivemq.cli.utils.LoggerUtils;
@@ -37,15 +34,12 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.tinylog.Logger;
-import org.tinylog.configuration.Configuration;
 import picocli.CommandLine;
 
 import javax.inject.Inject;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 @CommandLine.Command(name = "pub",
         versionProvider = MqttCLIMain.CLIVersionProvider.class,
@@ -79,8 +73,8 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
     @CommandLine.Option(names = {"-q", "--qos"}, converter = MqttQosConverter.class, defaultValue = "0", description = "Quality of service for the corresponding topic (default for all: 0)", order = 1)
     @NotNull private MqttQos[] qos;
 
-    @CommandLine.Option(names = {"-m", "--message"}, converter = ByteBufferConverter.class, required = true, description = "The message to publish", order = 1)
-    @NotNull private ByteBuffer message;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1", order = 1)
+    @NotNull MessagePayloadOptions message;
 
     @CommandLine.Option(names = {"-r", "--retain"}, negatable = true, description = "The message will be retained (default: false)", order = 1)
     @Nullable private Boolean retain;
@@ -172,7 +166,7 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
                  connectOptions() +
                 ", topics=" + Arrays.toString(topics) +
                 ", qos=" + Arrays.toString(qos) +
-                ", message=" + new String(message.array(), StandardCharsets.UTF_8) +
+                ", message=" + new String(message.getMessageBuffer().array(), StandardCharsets.UTF_8) +
                 (retain != null ? (", retain=" + retain) : "") +
                 (messageExpiryInterval != null ? (", messageExpiryInterval=" + messageExpiryInterval) : "") +
                 (payloadFormatIndicator != null ? (", payloadFormatIndicator=" + payloadFormatIndicator) : "") +
@@ -199,11 +193,7 @@ public class PublishCommand extends AbstractConnectFlags implements MqttAction, 
     @NotNull
     @Override
     public ByteBuffer getMessage() {
-        return message;
-    }
-
-    public void setMessage(final ByteBuffer message) {
-        this.message = message;
+        return message.getMessageBuffer();
     }
 
     @Nullable

--- a/src/main/java/com/hivemq/cli/commands/options/MessagePayloadOptions.java
+++ b/src/main/java/com/hivemq/cli/commands/options/MessagePayloadOptions.java
@@ -1,0 +1,27 @@
+package com.hivemq.cli.commands.options;
+
+import com.hivemq.cli.converters.ByteBufferConverter;
+import com.hivemq.cli.converters.FileToByteBufferConverter;
+import org.jetbrains.annotations.NotNull;
+import picocli.CommandLine;
+
+import java.nio.ByteBuffer;
+
+public class MessagePayloadOptions {
+
+    @CommandLine.Option(names = {"-m", "--message"}, converter = ByteBufferConverter.class, description = "The message to publish", order = 1)
+    public void setMessageFromCommandline(final @NotNull ByteBuffer messageFromFile) {
+        messageBuffer = messageFromFile;
+    }
+
+    @CommandLine.Option(names = {"-m:file", "--message-file"}, converter = FileToByteBufferConverter.class, description = "The message read in from a file", order = 1)
+    public void setMessageFromFile(final @NotNull ByteBuffer messageFromFile) {
+        messageBuffer = messageFromFile;
+    }
+
+    private @NotNull ByteBuffer messageBuffer;
+
+    public @NotNull ByteBuffer getMessageBuffer() {
+        return messageBuffer;
+    }
+}

--- a/src/main/java/com/hivemq/cli/commands/shell/ContextPublishCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/shell/ContextPublishCommand.java
@@ -17,6 +17,7 @@ package com.hivemq.cli.commands.shell;
 
 import com.google.common.base.Throwables;
 import com.hivemq.cli.commands.Publish;
+import com.hivemq.cli.commands.options.MessagePayloadOptions;
 import com.hivemq.cli.converters.ByteBufferConverter;
 import com.hivemq.cli.converters.Mqtt5UserPropertyConverter;
 import com.hivemq.cli.converters.MqttQosConverter;
@@ -66,8 +67,8 @@ public class ContextPublishCommand extends ShellContextCommand implements Runnab
     @CommandLine.Option(names = {"-q", "--qos"}, converter = MqttQosConverter.class, defaultValue = "0", description = "Quality of service for the corresponding topic (default for all: 0)")
     @NotNull private MqttQos[] qos;
 
-    @CommandLine.Option(names = {"-m", "--message"}, converter = ByteBufferConverter.class, required = true, description = "The message to publish")
-    @NotNull private ByteBuffer message;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    @NotNull MessagePayloadOptions message;
 
     @CommandLine.Option(names = {"-r", "--retain"}, negatable = true, defaultValue = "false", description = "The message will be retained (default: false)")
     @Nullable private Boolean retain;
@@ -134,7 +135,7 @@ public class ContextPublishCommand extends ShellContextCommand implements Runnab
                 "key=" + getKey() +
                 ", topics=" + Arrays.toString(topics) +
                 ", qos=" + Arrays.toString(qos) +
-                ", message=" + new String(message.array(), StandardCharsets.UTF_8) +
+                ", message=" + new String(message.getMessageBuffer().array(), StandardCharsets.UTF_8) +
                 ", retain=" + retain +
                 (messageExpiryInterval != null ? (", messageExpiryInterval=" + messageExpiryInterval) : "") +
                 (payloadFormatIndicator != null ? (", payloadFormatIndicator=" + payloadFormatIndicator) : "") +
@@ -160,11 +161,7 @@ public class ContextPublishCommand extends ShellContextCommand implements Runnab
     @NotNull
     @Override
     public ByteBuffer getMessage() {
-        return message;
-    }
-
-    public void setMessage(final ByteBuffer message) {
-        this.message = message;
+        return message.getMessageBuffer();
     }
 
     @Nullable

--- a/src/main/java/com/hivemq/cli/converters/FileToByteBufferConverter.java
+++ b/src/main/java/com/hivemq/cli/converters/FileToByteBufferConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.cli.converters;
+
+import org.jetbrains.annotations.NotNull;
+import picocli.CommandLine;
+
+import java.io.FileNotFoundException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FileToByteBufferConverter implements CommandLine.ITypeConverter<ByteBuffer> {
+
+    @Override
+    public @NotNull ByteBuffer convert(final @NotNull String fileName) throws Exception {
+        final Path path = Paths.get(fileName);
+        if (!Files.isReadable(path)) {
+            throw new FileNotFoundException("File not found or not readable: " + fileName);
+        }
+
+        return ByteBuffer.wrap(Files.readAllBytes(path));
+    }
+}


### PR DESCRIPTION
**Motivation**

Improve usability of the cli for scripted testing and development by submitting message payload from files.

**Changes**
Added the possibility to send file content with -m:file, like -pw:file allows for.