### PR TITLE
Fix/quick start links in mqtt-cli documentation

### DIFF
--- a/docs/_docs/logging.md
+++ b/docs/_docs/logging.md
@@ -6,7 +6,7 @@ redirect_from: /docs/logging.html
 # Logging
 ***
 * All non-shell commands offer an ``-l`` option by which logging to a logfile under ``~/.mqtt-cli/logs`` can be activated
-* The logfile and loglevel can be configured in the [MQTT-CLI configuration](/docs/configuration)
+* The logfile and loglevel can be configured in the [MQTT-CLI configuration](../configuration)
 * By specifying the ``-l`` option for the ``shell`` command the whole shell-session will be logged to a logfile shown at start
 
 ## Direct logging for publish & subscribe

--- a/docs/_docs/logging.md
+++ b/docs/_docs/logging.md
@@ -6,7 +6,7 @@ redirect_from: /docs/logging.html
 # Logging
 ***
 * All non-shell commands offer an ``-l`` option by which logging to a logfile under ``~/.mqtt-cli/logs`` can be activated
-* The logfile and loglevel can be configured in the [MQTT-CLI configuration](configuration)
+* The logfile and loglevel can be configured in the [MQTT-CLI configuration](/docs/configuration)
 * By specifying the ``-l`` option for the ``shell`` command the whole shell-session will be logged to a logfile shown at start
 
 ## Direct logging for publish & subscribe

--- a/docs/_docs/quick-start.md
+++ b/docs/_docs/quick-start.md
@@ -8,7 +8,7 @@ redirect_from: /docs/quick_start.html
 ***
 ## Usage
 
-To install MQTT CLI on your system please follow the [Installation instructions](/docs/installation).
+To install MQTT CLI on your system please follow the [Installation instructions](../installation).
 
 The easiest way to start the CLI is by typing:
 ``` $ mqtt ```
@@ -40,12 +40,12 @@ $ mqtt [flags] [METHOD] [OPTION [OPTION]]
 
 ## Supported commands at start
 
-* [Publish](/docs/publish)
-* [Subscribe](/docs/subscribe)
-* [Shell](/docs/shell)
-* [Test](/docs/test) 
-* [HiveMQ](/docs/hivemq)
-* [Swarm](/docs/swarm) 
+* [Publish](../publish)
+* [Subscribe](../subscribe)
+* [Shell](../shell)
+* [Test](../test) 
+* [HiveMQ](../hivemq)
+* [Swarm](../swarm) 
 
 ***
 
@@ -59,7 +59,7 @@ This command:
 * publishes a message to a defined topic, 
 * disconnects the mqtt client from the broker
 
-> See [Publish](/docs/publish) for a detailed overview of the publish command
+> See [Publish](../publish) for a detailed overview of the publish command
 
 ***
 
@@ -74,7 +74,7 @@ This command:
 * stays connected to retrieve messages published to the given topic
 * exits and disconnects the client on **Ctrl + C** 
 
-> See [Subscribe](/docs/subscribe) for a detailed overview of the subscribe command
+> See [Subscribe](../subscribe) for a detailed overview of the subscribe command
 
 ***
 
@@ -86,7 +86,7 @@ $ mqtt shell
 mqtt>
 ```
 
-The shell mode enables you to execute more complex MQTT behaviour - see [Shell](/docs/shell) 
+The shell mode enables you to execute more complex MQTT behaviour - see [Shell](../shell) 
 
 ## Testing a MQTT broker
 

--- a/docs/_docs/quick-start.md
+++ b/docs/_docs/quick-start.md
@@ -8,7 +8,7 @@ redirect_from: /docs/quick_start.html
 ***
 ## Usage
 
-To install MQTT CLI on your system please follow the [Installation instructions](installation).
+To install MQTT CLI on your system please follow the [Installation instructions](/docs/installation).
 
 The easiest way to start the CLI is by typing:
 ``` $ mqtt ```
@@ -40,12 +40,12 @@ $ mqtt [flags] [METHOD] [OPTION [OPTION]]
 
 ## Supported commands at start
 
-* [Publish](publish)
-* [Subscribe](subscribe)
-* [Shell](shell)
-* [Test](test) 
-* [HiveMQ](hivemq)
-* [Swarm](swarm) 
+* [Publish](/docs/publish)
+* [Subscribe](/docs/subscribe)
+* [Shell](/docs/shell)
+* [Test](/docs/test) 
+* [HiveMQ](/docs/hivemq)
+* [Swarm](/docs/swarm) 
 
 ***
 
@@ -59,7 +59,7 @@ This command:
 * publishes a message to a defined topic, 
 * disconnects the mqtt client from the broker
 
-> See [Publish](publish) for a detailed overview of the publish command
+> See [Publish](/docs/publish) for a detailed overview of the publish command
 
 ***
 
@@ -74,7 +74,7 @@ This command:
 * stays connected to retrieve messages published to the given topic
 * exits and disconnects the client on **Ctrl + C** 
 
-> See [Subscribe](subscribe) for a detailed overview of the subscribe command
+> See [Subscribe](/docs/subscribe) for a detailed overview of the subscribe command
 
 ***
 
@@ -86,7 +86,7 @@ $ mqtt shell
 mqtt>
 ```
 
-The shell mode enables you to execute more complex MQTT behaviour - see [Shell](shell) 
+The shell mode enables you to execute more complex MQTT behaviour - see [Shell](/docs/shell) 
 
 ## Testing a MQTT broker
 

--- a/docs/_docs/shell.md
+++ b/docs/_docs/shell.md
@@ -40,23 +40,23 @@ mqtt> ...
 
 ### Commands **without** an active context
 
-* [Connect](shell/connect)
-* [Disconnect](shell/disconnect)
-* [Switch](shell/switch)
-* [List](shell/list)
-* [Clear](shell/clear)
-* [Exit](shell/exit)
+* [Connect](connect)
+* [Disconnect](disconnect)
+* [Switch](switch)
+* [List](list)
+* [Clear](clear)
+* [Exit](exit)
 
 ### Commands **with** an active context
 
-* [Publish](shell/publish)
-* [Subscribe](shell/subscribe)
-* [Unsubscribe](shell/unsubscribe)
-* [Disconnect](shell/disconnect)
-* [Switch](shell/switch)
-* [List](shell/list)
-* [Clear](shell/clear)
-* [Exit](shell/exit)
+* [Publish](publish)
+* [Subscribe](subscribe)
+* [Unsubscribe](unsubscribe)
+* [Disconnect](disconnect)
+* [Switch](switch)
+* [List](list)
+* [Clear](clear)
+* [Exit](exit)
 
 
 

--- a/docs/_docs/shell/connect.md
+++ b/docs/_docs/shell/connect.md
@@ -7,8 +7,8 @@ redirect_from: /docs/shell/connect.html
 ***
 
 The Connect command creates a client and connects it to the specified broker.
-The client will stay connected until it is disconnected by the broker or the [Disconnect](/docs/shell/disconnect) method is called.
-To list all of the connected clients use the [List](/docs/shell/list) method.
+The client will stay connected until it is disconnected by the broker or the [Disconnect](../shell/disconnect) method is called.
+To list all of the connected clients use the [List](../shell/list) method.
 
 ## Simple Examples
 

--- a/docs/_docs/shell/connect.md
+++ b/docs/_docs/shell/connect.md
@@ -7,8 +7,8 @@ redirect_from: /docs/shell/connect.html
 ***
 
 The Connect command creates a client and connects it to the specified broker.
-The client will stay connected until it is disconnected by the broker or the [Disconnect](disconnect) method is called.
-To list all of the connected clients use the [List](list) method.
+The client will stay connected until it is disconnected by the broker or the [Disconnect](/docs/shell/disconnect) method is called.
+To list all of the connected clients use the [List](/docs/shell/list) method.
 
 ## Simple Examples
 

--- a/docs/_docs/shell/publish.md
+++ b/docs/_docs/shell/publish.md
@@ -6,7 +6,7 @@ redirect_from: /docs/shell/publish.html
 # Publish
 ***
 
-The publish with a context works almost the same as [Publish](/docs/publish) but it will not create a new connection and publish with a new client.
+The publish with a context works almost the same as [Publish](../publish) but it will not create a new connection and publish with a new client.
 Instead it uses the currently active context client.
 
 ## Synopsis

--- a/docs/_docs/shell/subscribe.md
+++ b/docs/_docs/shell/subscribe.md
@@ -7,7 +7,7 @@ redirect_from: /docs/shell/subscribe.html
 ***
 
 The subscribe with a context subscribes the currently active context client to the given topics.
-By default it doesn't block the console like the [Subscribe](/docs/subscribe) without a context does.
+By default it doesn't block the console like the [Subscribe](../subscribe) without a context does.
 To enable this behavior you can use the **-s** option.
 
 
@@ -46,7 +46,7 @@ client@host> sub    -t <topics> [-t <topics>]...
 ## Examples
 
 > Subscribe to test topic on default settings (output will be written to Logfile.
-See [Logging](/docs/logging)):
+See [Logging](../logging)):
 
 ```
 mqtt> con -i myClient


### PR DESCRIPTION
**Motivation**
during onboarding, I noticed a lot of wrong links in the CLI docs, the info is still there but only reachable using the navigation bar. This is not ideal and may put people off.

**Changes**
This PR fixes all site internal links. Every link change was tested locally using jekyll 