### PR TITLE
Subscribe Command > Fix NPE when not specifying a client id

### DIFF
--- a/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
@@ -115,7 +115,7 @@ abstract class AbstractMqttClientExecutor {
             // This check only works as subscribes are implemented blocking.
             // Otherwise, we would need to check the topics before they are iterated as they are added to the client data after a successful subscribe.
             final List<MqttTopicFilter> intersectingFilters =
-                    checkForSharedTopicDuplicate(clientKeyToClientData.get(subscribe.getKey()).getSubscribedTopics(),
+                    checkForSharedTopicDuplicate(clientKeyToClientData.get(getClientDataKey(client)).getSubscribedTopics(),
                             topic);
 
             if (!intersectingFilters.isEmpty()) {
@@ -507,5 +507,11 @@ abstract class AbstractMqttClientExecutor {
                     mqtt3Publish,
                     new String(mqtt3Publish.getPayloadAsBytes(), StandardCharsets.UTF_8));
         }
+    }
+
+    private @NotNull String getClientDataKey(final @NotNull MqttClient client) {
+        final String clientId = client.getConfig().getClientIdentifier().map(Objects::toString).orElse("null");
+        final String serverHost = client.getConfig().getServerHost();
+        return "client {" + "identifier='" + clientId + '\'' + ", host='" + serverHost + '\'' + '}';
     }
 }

--- a/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
@@ -112,10 +112,13 @@ abstract class AbstractMqttClientExecutor {
         for (int i = 0; i < subscribe.getTopics().length; i++) {
             final String topic = subscribe.getTopics()[i];
 
+            final String key = MqttUtils.buildKey(client.getConfig().getClientIdentifier().map(Object::toString).orElse(""),
+                    client.getConfig().getServerHost());
+
             // This check only works as subscribes are implemented blocking.
             // Otherwise, we would need to check the topics before they are iterated as they are added to the client data after a successful subscribe.
             final List<MqttTopicFilter> intersectingFilters =
-                    checkForSharedTopicDuplicate(clientKeyToClientData.get(getClientDataKey(client)).getSubscribedTopics(),
+                    checkForSharedTopicDuplicate(clientKeyToClientData.get(key).getSubscribedTopics(),
                             topic);
 
             if (!intersectingFilters.isEmpty()) {

--- a/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
+++ b/src/main/java/com/hivemq/cli/mqtt/AbstractMqttClientExecutor.java
@@ -511,10 +511,4 @@ abstract class AbstractMqttClientExecutor {
                     new String(mqtt3Publish.getPayloadAsBytes(), StandardCharsets.UTF_8));
         }
     }
-
-    private @NotNull String getClientDataKey(final @NotNull MqttClient client) {
-        final String clientId = client.getConfig().getClientIdentifier().map(Objects::toString).orElse("null");
-        final String serverHost = client.getConfig().getServerHost();
-        return "client {" + "identifier='" + clientId + '\'' + ", host='" + serverHost + '\'' + '}';
-    }
 }


### PR DESCRIPTION
Just an intermediate fix. 
A refactored version can be found in #308, which moves the client key out of the abstract command and into an own class. 