### PR TITLE
Use commons-text version 1.10.0 or later. This resolves CVE-2022-42889.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,12 @@ dependencies {
     implementation("io.netty:netty-codec-http:${property("netty.version")}")
     implementation("io.netty:netty-transport-native-epoll:${property("netty.version")}:linux-x86_64")
     implementation("com.opencsv:opencsv:${property("open-csv.version")}")
+    constraints {
+        implementation("org.apache.commons:commons-text:1.10.0") {
+            because("Force a commons-text version that does not contain CVE-2022-42889, " +
+                    "because opencsv brings the vulnerable version 1.9 as transitive dependency")
+        }
+    }
 }
 
 /* ******************** OpenAPI ******************** */


### PR DESCRIPTION
**Motivation**

The MQTT CLI uses apache commons text version 1.9 and that contains the critical vulnerability CVE-2022-42889: https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Apache commons text comes as transitive dependency from opencsv and the current version 5.7.0 still depends on the vulnerable version 1.9: https://mvnrepository.com/artifact/com.opencsv/opencsv/5.7.0

**Changes**

Force the common text dependency to version 1.10.0 or later. The version 1.10.0 contains the fix for the vulnerability. 

https://hivemq.kanbanize.com/ctrl_board/22/cards/9679/details/