### PR TITLE
Fix TrustManagerFactory default algorithm

### DIFF
--- a/src/main/java/com/hivemq/cli/commands/options/TlsOptions.java
+++ b/src/main/java/com/hivemq/cli/commands/options/TlsOptions.java
@@ -339,7 +339,7 @@ public class TlsOptions {
                     i++;
                 }
             }
-            trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             trustManagerFactory.init(keyStore);
         } else if (defaultTruststoreExists) {
             final String defaultTruststorePassword = defaultCLIProperties.getTruststorePassword();


### PR DESCRIPTION
Fix a bug which caused certificates to not be recognized due to a wrong default algorithm.

https://hivemq.kanbanize.com/ctrl_board/22/cards/17043/details/