### PR TITLE
Update eclipse-temurin to db16895

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -638,7 +638,7 @@ oci {
     imageDefinitions.register("main") {
         allPlatforms {
             dependencies {
-                runtime("library:eclipse-temurin:sha256!8234720ae5083d3b972fe20b4a997b7c56546db8bf8da5f4c54c6470901e2e67") // 21-jre-jammy
+                runtime("library:eclipse-temurin:sha256!db1689535962d757a5adabf57387584ed543d38c0b9d1fe870123ea362ad73b0") // 21-jre-jammy
             }
             config {
                 entryPoint.add("java")


### PR DESCRIPTION
https://hub.docker.com/layers/library/eclipse-temurin/21-jre-jammy/images/sha256-cddd554e8d69b48b46e8b0c9d1ce72ae5fe8d84819dcdb7131328531e9cc100b