### PR TITLE
Add setup-gradle with cache-disabled and setup-java caching

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,6 +51,10 @@ jobs:
             11
             21
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Setup GraalVM
         run: ./gradlew installNativeImageTooling
       - name: Warmup Gradle cache
@@ -77,6 +81,10 @@ jobs:
             11
             21
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Run unit tests
         run: ./gradlew test --stacktrace
       - name: Upload test results
@@ -129,6 +137,10 @@ jobs:
             11
             21
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Compile integration tests
         run: ./gradlew compileIntegrationTestJava
       - name: Split tests
@@ -219,6 +231,10 @@ jobs:
             11
             21
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Compile system tests
         run: ./gradlew compileSystemTestJava shadowJar
       - name: Split tests
@@ -309,6 +325,10 @@ jobs:
             11
             21
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Setup GraalVM
         run: ./gradlew installNativeImageTooling
       - name: Compile native system tests
@@ -386,6 +406,10 @@ jobs:
             11
             21
           cache: gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Build packages
         run: ./gradlew buildPackages shadowDistZip
       - name: Upload distribution

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,15 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Publish
         env:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `setup-gradle` with `cache-disabled: true` to all workflows running Gradle
- Add `cache: gradle` to `setup-java` where missing (MIT-licensed, writes on all branches)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)