### PR TITLE
Fix Swarm stop commander base path

### DIFF
--- a/src/main/java/com/hivemq/cli/commands/swarm/run/SwarmRunStopCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/swarm/run/SwarmRunStopCommand.java
@@ -96,6 +96,7 @@ public class SwarmRunStopCommand implements Callable<Integer> {
         }
 
         runsApi.getApiClient().setBasePath(swarmOptions.getCommanderUrl());
+        commanderApi.getApiClient().setBasePath(swarmOptions.getCommanderUrl());
 
         final int usedRunID;
         if (runId == null) {

--- a/src/test/java/com/hivemq/cli/commands/swarm/run/SwarmRunStopCommandTest.java
+++ b/src/test/java/com/hivemq/cli/commands/swarm/run/SwarmRunStopCommandTest.java
@@ -36,7 +36,8 @@ class SwarmRunStopCommandTest {
 
     private @NotNull RunsApi runsApi;
     private @NotNull SwarmApiErrorTransformer errorTransformer;
-    private @NotNull ApiClient apiClient;
+    private @NotNull ApiClient runsApiClient;
+    private @NotNull ApiClient commanderApiClient;
     private @NotNull CommanderApi commanderApi;
     private @NotNull PrintStream out;
 
@@ -47,8 +48,10 @@ class SwarmRunStopCommandTest {
         commanderApi = mock(CommanderApi.class);
         errorTransformer = mock(SwarmApiErrorTransformer.class);
 
-        apiClient = mock(ApiClient.class);
-        when(runsApi.getApiClient()).thenReturn(apiClient);
+        runsApiClient = mock(ApiClient.class);
+        commanderApiClient = mock(ApiClient.class);
+        when(runsApi.getApiClient()).thenReturn(runsApiClient);
+        when(commanderApi.getApiClient()).thenReturn(commanderApiClient);
 
         final Error error = mock(Error.class);
         when(errorTransformer.transformError(any())).thenReturn(error);
@@ -59,7 +62,8 @@ class SwarmRunStopCommandTest {
         final SwarmRunStopCommand invalid = new SwarmRunStopCommand("invalid", 1, runsApi, commanderApi, errorTransformer, out);
         assertEquals(-1, invalid.call());
         verify(runsApi, times(0)).getRun(any());
-        verify(apiClient, times(0)).setBasePath(anyString());
+        verify(runsApiClient, times(0)).setBasePath(anyString());
+        verify(commanderApiClient, times(0)).setBasePath(anyString());
     }
 
     @Test
@@ -70,7 +74,8 @@ class SwarmRunStopCommandTest {
 
         assertEquals(-1, invalid.call());
         verify(runsApi).stopRun(eq("1"), any());
-        verify(apiClient).setBasePath("http://localhost:8080");
+        verify(runsApiClient).setBasePath("http://localhost:8080");
+        verify(commanderApiClient).setBasePath("http://localhost:8080");
         verify(errorTransformer).transformError(any());
     }
 
@@ -80,7 +85,8 @@ class SwarmRunStopCommandTest {
 
         assertEquals(0, invalid.call());
         verify(runsApi).stopRun(eq("1"), any());
-        verify(apiClient).setBasePath("http://localhost:8080");
+        verify(runsApiClient).setBasePath("http://localhost:8080");
+        verify(commanderApiClient).setBasePath("http://localhost:8080");
         verify(errorTransformer, times(0)).transformError(any());
     }
 
@@ -93,7 +99,8 @@ class SwarmRunStopCommandTest {
 
         assertEquals(-1, invalid.call());
         verify(runsApi, times(0)).stopRun(eq("1"), any());
-        verify(apiClient).setBasePath("http://localhost:8080");
+        verify(runsApiClient).setBasePath("http://localhost:8080");
+        verify(commanderApiClient).setBasePath("http://localhost:8080");
         verify(errorTransformer).transformError(any());
     }
 
@@ -107,7 +114,8 @@ class SwarmRunStopCommandTest {
 
         assertEquals(0, invalid.call());
         verify(runsApi, times(0)).stopRun(eq("1"), any());
-        verify(apiClient).setBasePath("http://localhost:8080");
+        verify(runsApiClient).setBasePath("http://localhost:8080");
+        verify(commanderApiClient).setBasePath("http://localhost:8080");
         verify(errorTransformer, times(0)).transformError(any());
 
     }
@@ -122,7 +130,8 @@ class SwarmRunStopCommandTest {
 
         assertEquals(0, invalid.call());
         verify(runsApi).stopRun(eq("1337"), any());
-        verify(apiClient).setBasePath("http://localhost:8080");
+        verify(runsApiClient).setBasePath("http://localhost:8080");
+        verify(commanderApiClient).setBasePath("http://localhost:8080");
         verify(errorTransformer, times(0)).transformError(any());
     }
 }


### PR DESCRIPTION
## Summary
- configure both RunsApi and CommanderApi with the selected commander URL in SwarmRunStopCommand
- tighten SwarmRunStopCommandTest so both API clients are verified independently
- keep the fix local to the stop-command seam selected by the Pi Loop onboarding survey

## Testing
- ./gradlew test --tests com.hivemq.cli.commands.swarm.run.SwarmRunStopCommandTest
- ./gradlew compileJava