### PR TITLE
Clean up uploaded scenarios on start failure

### DIFF
--- a/src/main/java/com/hivemq/cli/commands/swarm/run/SwarmRunStartCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/swarm/run/SwarmRunStartCommand.java
@@ -187,6 +187,7 @@ public class SwarmRunStartCommand implements Callable<Integer> {
             final Error error = errorTransformer.transformError(e);
             Logger.error("Could not execute the scenario. {}.", error.getDetail());
             System.err.println("Could not execute the scenario. " + error.getDetail());
+            deleteScenarioAfterFailedStart(scenarioId);
             return -1;
         }
 
@@ -194,6 +195,7 @@ public class SwarmRunStartCommand implements Callable<Integer> {
         if (runId == null) {
             Logger.error("Start run response did not contain a run-id:\n {}", startRunResponse.toString());
             System.err.println("Start run response did not contain a run-id:\n " + startRunResponse);
+            deleteScenarioAfterFailedStart(scenarioId);
             return -1;
         }
         out.println("Run id: " + runId);
@@ -217,6 +219,15 @@ public class SwarmRunStartCommand implements Callable<Integer> {
             }
         }
         return 0;
+    }
+
+    private void deleteScenarioAfterFailedStart(final int scenarioId) {
+        try {
+            scenariosApi.deleteScenario(Integer.toString(scenarioId));
+        } catch (final ApiException e) {
+            final Error error = errorTransformer.transformError(e);
+            Logger.error("Failed to delete uploaded scenario '{}'. {}.", scenarioId, error.getDetail());
+        }
     }
 
     private void pollUntilFinished(final int runId) throws ApiException {

--- a/src/test/java/com/hivemq/cli/commands/swarm/run/SwarmRunStartCommandTest.java
+++ b/src/test/java/com/hivemq/cli/commands/swarm/run/SwarmRunStartCommandTest.java
@@ -218,8 +218,38 @@ class SwarmRunStartCommandTest {
         assertEquals(-1, command.call());
         verify(apiClient, times(2)).setBasePath("http://localhost:8080");
         verify(scenariosApi).uploadScenario(any());
+        verify(scenariosApi).deleteScenario("1");
         verify(swarmApiErrorTransformer).transformError(any());
         verify(runsApi).startRun(any());
+    }
+
+    @Test
+    void startRunWithoutRunId_deletesUploadedScenario(final @TempDir @NotNull Path tempDir)
+            throws IOException, ApiException {
+        final Path scenario = tempDir.resolve("scenario.vm");
+        Files.writeString(scenario, "scenario-content");
+
+        final SwarmRunStartCommand command = new SwarmRunStartCommand("http://localhost:8080",
+                scenario.toFile(),
+                true,
+                runsApi,
+                scenariosApi,
+                swarmApiErrorTransformer,
+                System.out);
+
+        final UploadScenarioResponse uploadScenarioResponse = mock(UploadScenarioResponse.class);
+        when(scenariosApi.uploadScenario(any())).thenReturn(uploadScenarioResponse);
+        when(uploadScenarioResponse.getScenarioId()).thenReturn(42);
+
+        final StartRunResponse startRunResponse = mock(StartRunResponse.class);
+        when(startRunResponse.getRunId()).thenReturn(null);
+        when(runsApi.startRun(any())).thenReturn(startRunResponse);
+
+        assertEquals(-1, command.call());
+        verify(apiClient, times(2)).setBasePath("http://localhost:8080");
+        verify(scenariosApi).uploadScenario(any());
+        verify(runsApi).startRun(any());
+        verify(scenariosApi).deleteScenario("42");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- delete uploaded scenarios when SwarmRunStartCommand fails after upload during startRun
- also clean up when the start response is missing a run id
- cover the new cleanup behavior with focused unit tests

## Testing
- ./gradlew test --tests com.hivemq.cli.commands.swarm.run.SwarmRunStartCommandTest
- ./gradlew compileJava