### PR TITLE
Add insecure TLS option to mqtt test

### DIFF
--- a/docs/_docs/test.md
+++ b/docs/_docs/test.md
@@ -56,6 +56,7 @@ MQTT 5: OK
 | `-a`   | `--all`         | Perform all tests for all MQTT versions.                                       | `false` (Only test MQTT 3)   |
 | `-t`   | `--timeOut`     | The time to wait for the broker to respond (in seconds).                       | `10`                         |
 | `-q`   | `--qosTries`    | The amount of messages to send and receive from the broker for each QoS level. | `10`                         |
+|        | `--insecure`    | Disable TLS certificate and hostname validation for this test connection.       | `false`                      |
 
 ### Connect Options
 

--- a/src/main/java/com/hivemq/cli/commands/cli/TestBrokerCommand.java
+++ b/src/main/java/com/hivemq/cli/commands/cli/TestBrokerCommand.java
@@ -95,6 +95,12 @@ public class TestBrokerCommand implements Callable<Integer> {
                         description = "Log to $HOME/.mqtt-cli/logs (Configurable through $HOME/.mqtt-cli/config.properties)")
     private boolean logToLogfile;
 
+    @SuppressWarnings("unused")
+    @CommandLine.Option(names = {"--insecure"},
+                        defaultValue = "false",
+                        description = "Disable TLS certificate and hostname validation for this test connection")
+    private boolean insecure;
+
     @CommandLine.Mixin
     private final @NotNull AuthenticationOptions authenticationOptions = new AuthenticationOptions();
 
@@ -127,6 +133,7 @@ public class TestBrokerCommand implements Callable<Integer> {
         }
 
         authenticationOptions.setDefaultOptions();
+        tlsOptions.setInsecure(insecure);
 
         try {
             sslConfig = tlsOptions.buildSslConfig();

--- a/src/main/java/com/hivemq/cli/commands/options/TlsOptions.java
+++ b/src/main/java/com/hivemq/cli/commands/options/TlsOptions.java
@@ -21,16 +21,25 @@ import com.hivemq.cli.DefaultCLIProperties;
 import com.hivemq.cli.MqttCLIMain;
 import com.hivemq.cli.utils.TlsUtil;
 import com.hivemq.client.mqtt.MqttClientSslConfig;
+import com.hivemq.client.mqtt.MqttClientSslConfigBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.tinylog.Logger;
 import picocli.CommandLine;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.net.Socket;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,6 +48,9 @@ import java.util.Objects;
 public class TlsOptions {
 
     private static final @NotNull String DEFAULT_TLS_VERSION = "TLSv1.2";
+    private static final @NotNull TrustManagerFactory INSECURE_TRUST_MANAGER_FACTORY =
+            new InsecureTrustManagerFactory();
+    private static final @NotNull HostnameVerifier INSECURE_HOSTNAME_VERIFIER = (hostname, session) -> true;
 
     @SuppressWarnings("unused")
     @CommandLine.Option(names = {"-s", "--secure"},
@@ -105,25 +117,35 @@ public class TlsOptions {
     @CommandLine.Option(names = {"--tspw", "--truststore-password"}, description = "The password for the truststore")
     private @Nullable String clientTruststorePassword;
 
+    private boolean insecure;
+
+    public void setInsecure(final boolean insecure) {
+        this.insecure = insecure;
+    }
+
     public @Nullable MqttClientSslConfig buildSslConfig() throws Exception {
         if (!useTls()) {
             return null;
         }
 
         final KeyManagerFactory keyManagerFactory = buildKeyManagerFactory();
-        final TrustManagerFactory trustManagerFactory = buildTrustManagerFactory();
+        final TrustManagerFactory trustManagerFactory =
+                insecure ? INSECURE_TRUST_MANAGER_FACTORY : buildTrustManagerFactory();
 
         if (supportedTLSVersions == null) {
             supportedTLSVersions = new ArrayList<>();
             supportedTLSVersions.add(DEFAULT_TLS_VERSION);
         }
 
-        return MqttClientSslConfig.builder()
+        final MqttClientSslConfigBuilder builder = MqttClientSslConfig.builder()
                 .trustManagerFactory(trustManagerFactory)
                 .keyManagerFactory(keyManagerFactory)
                 .cipherSuites(cipherSuites)
-                .protocols(supportedTLSVersions)
-                .build();
+                .protocols(supportedTLSVersions);
+        if (insecure) {
+            builder.hostnameVerifier(INSECURE_HOSTNAME_VERIFIER);
+        }
+        return builder.build();
     }
 
     /**
@@ -433,6 +455,7 @@ public class TlsOptions {
                 supportedTLSVersions != null ||
                 clientPrivateKeyPath != null ||
                 clientCertificatePath != null ||
+                insecure ||
                 useTls;
     }
 
@@ -453,6 +476,82 @@ public class TlsOptions {
                 clientCertificatePath +
                 ", clientPrivateKey=" +
                 clientPrivateKeyPath +
+                ", insecure=" +
+                insecure +
                 '}';
+    }
+
+    private static class InsecureTrustManagerFactory extends TrustManagerFactory {
+
+        private static final @NotNull Provider PROVIDER =
+                new Provider("mqtt-cli-insecure", "1.0", "Trust manager for explicitly insecure MQTT CLI TLS") {
+                };
+
+        InsecureTrustManagerFactory() {
+            super(new InsecureTrustManagerFactorySpi(), PROVIDER, "insecure");
+        }
+    }
+
+    private static class InsecureTrustManagerFactorySpi extends TrustManagerFactorySpi {
+
+        private static final @NotNull TrustManager @NotNull [] TRUST_MANAGERS =
+                new TrustManager[]{new InsecureX509TrustManager()};
+
+        @Override
+        protected void engineInit(final @Nullable KeyStore keyStore) {
+        }
+
+        @Override
+        protected void engineInit(final @Nullable ManagerFactoryParameters managerFactoryParameters) {
+        }
+
+        @Override
+        protected @NotNull TrustManager @NotNull [] engineGetTrustManagers() {
+            return TRUST_MANAGERS;
+        }
+    }
+
+    private static class InsecureX509TrustManager extends X509ExtendedTrustManager {
+
+        @Override
+        public void checkClientTrusted(final X509Certificate @NotNull [] chain, final @NotNull String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(final X509Certificate @NotNull [] chain, final @NotNull String authType) {
+        }
+
+        @Override
+        public X509Certificate @NotNull [] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+
+        @Override
+        public void checkClientTrusted(
+                final X509Certificate @NotNull [] chain,
+                final @NotNull String authType,
+                final @Nullable Socket socket) {
+        }
+
+        @Override
+        public void checkServerTrusted(
+                final X509Certificate @NotNull [] chain,
+                final @NotNull String authType,
+                final @Nullable Socket socket) {
+        }
+
+        @Override
+        public void checkClientTrusted(
+                final X509Certificate @NotNull [] chain,
+                final @NotNull String authType,
+                final @Nullable SSLEngine engine) {
+        }
+
+        @Override
+        public void checkServerTrusted(
+                final X509Certificate @NotNull [] chain,
+                final @NotNull String authType,
+                final @Nullable SSLEngine engine) {
+        }
     }
 }

--- a/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandTest.java
+++ b/src/test/java/com/hivemq/cli/commands/cli/TestBrokerCommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hivemq.cli.commands.cli;
+
+import com.hivemq.cli.DefaultCLIProperties;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestBrokerCommandTest {
+
+    @Test
+    void testCommand_exposesInsecureOption(@TempDir final @NotNull Path tempDir) throws Exception {
+        final DefaultCLIProperties defaultCLIProperties = new DefaultCLIProperties(tempDir.resolve("config.properties"));
+        final CommandLine commandLine = new CommandLine(new TestBrokerCommand(defaultCLIProperties));
+
+        assertTrue(commandLine.getCommandSpec().optionsMap().containsKey("--insecure"));
+    }
+}

--- a/src/test/java/com/hivemq/cli/commands/options/TlsOptionsTest.java
+++ b/src/test/java/com/hivemq/cli/commands/options/TlsOptionsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hivemq.cli.commands.options;
+
+import com.hivemq.cli.DefaultCLIProperties;
+import com.hivemq.cli.MqttCLIMain;
+import com.hivemq.cli.ioc.MqttCLI;
+import com.hivemq.client.mqtt.MqttClientSslConfig;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TlsOptionsTest {
+
+    @BeforeEach
+    void setUp(@TempDir final @NotNull Path tempDir) throws Exception {
+        final DefaultCLIProperties defaultCLIProperties = new DefaultCLIProperties(tempDir.resolve("config.properties"));
+
+        final MqttCLI mqttCLI = mock(MqttCLI.class);
+        when(mqttCLI.defaultCLIProperties()).thenReturn(defaultCLIProperties);
+        MqttCLIMain.MQTT_CLI = mqttCLI;
+    }
+
+    @AfterEach
+    void tearDown() {
+        MqttCLIMain.MQTT_CLI = null;
+    }
+
+    @Test
+    void buildSslConfig_noTlsOptions_returnsNull() throws Exception {
+        final TlsOptions tlsOptions = new TlsOptions();
+
+        assertNull(tlsOptions.buildSslConfig());
+    }
+
+    @Test
+    void buildSslConfig_secureOnly_keepsDefaultTrustAndHostnameValidation() throws Exception {
+        final TlsOptions tlsOptions = new TlsOptions();
+        new CommandLine(tlsOptions).parseArgs("--secure");
+
+        final MqttClientSslConfig sslConfig = tlsOptions.buildSslConfig();
+
+        assertNotNull(sslConfig);
+        assertFalse(sslConfig.getTrustManagerFactory().isPresent());
+        assertFalse(sslConfig.getHostnameVerifier().isPresent());
+    }
+
+    @Test
+    void buildSslConfig_insecure_usesTrustAllAndHostnameVerifier() throws Exception {
+        final TlsOptions tlsOptions = new TlsOptions();
+        tlsOptions.setInsecure(true);
+
+        final MqttClientSslConfig sslConfig = tlsOptions.buildSslConfig();
+
+        assertNotNull(sslConfig);
+        assertTrue(sslConfig.getHostnameVerifier().orElseThrow().verify("untrusted.example", null));
+        final TrustManager trustManager =
+                sslConfig.getTrustManagerFactory().orElseThrow().getTrustManagers()[0];
+        assertTrue(trustManager instanceof X509TrustManager);
+        assertDoesNotThrow(() -> ((X509TrustManager) trustManager).checkServerTrusted(new X509Certificate[0], "RSA"));
+    }
+
+    @Test
+    void tlsOptions_doesNotExposeInsecureCliOptionDirectly() {
+        final CommandLine commandLine = new CommandLine(new TlsOptions());
+
+        assertFalse(commandLine.getCommandSpec().optionsMap().containsKey("--insecure"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `--insecure` to `mqtt test` so users can deliberately run TLS broker tests while ignoring certificate/trust validation failures.

## Details

- Exposes `--insecure` only on `TestBrokerCommand`
- Wires the flag into `TlsOptions` through a programmatic toggle, so publish/subscribe/shell TLS options are not broadened
- Uses a trust-all `TrustManagerFactory` plus hostname verifier only when insecure mode is explicitly enabled
- Keeps normal `--secure` behavior on the default trust and hostname validation path
- Documents the new option in the test command docs

## Validation

- `./gradlew compileJava`
- `./gradlew test --tests '*TestBrokerCommand*' --tests '*TlsOptions*'`
- `./gradlew test`

Pi Loop reviewer: Claude Sonnet 4.6 promoted the iteration with zero findings.
