### PR TITLE
Remove outdated Kanbanize project tags from Snyk workflows

### DIFF
--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -43,6 +43,5 @@ jobs:
         run: >
           snyk monitor --configuration-matching=^runtimeClasspath$ --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-mqtt-cli
           --project-name=mqtt-cli --remote-repo-url=mqtt-cli --project-lifecycle=development mqtt-cli -d
-          --project-tags=kanbanize_board_name="\"Tooling++&++Extension,kanbanize_board_workflow_name=Development++Workflow,kanbanize_board_column_name=Selected,kanbanize_board_swimlane=Expedite,kanbanize_board_done_sections=4/5\""
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Summary

Remove the outdated Kanbanize `--project-tags` arguments from the Snyk workflows. These project tags were once used for a Kanbanize integration that is no longer in use.

INT-350
