### PR TITLE
PLT-1261: migrate base image to ECR Public

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -624,9 +624,6 @@ oci {
         dockerHub {
             optionalCredentials()
         }
-        // The eclipse-temurin base image is served from ECR Public (PLT-1261). The registry host, namespace and
-        // group are read from oci.versions.toml so the image is declared in exactly one place; anonymous pulls
-        // need no credentials. exclusiveContent keeps this group from also being looked up on Docker Hub.
         registry(ociImages.eclipse.temurin.registry!!) {
             url = uri("https://${ociImages.eclipse.temurin.registry}")
             exclusiveContent { includeGroup(ociImages.eclipse.temurin.group) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -306,7 +306,7 @@ testing {
 
             oci.of(this) {
                 imageDependencies {
-                    runtime(project).tag("latest")
+                    runtime(project()).tag("latest")
                 }
                 val linuxAmd64 = platformSelector(platform("linux", "amd64"))
                 val linuxArm64v8 = platformSelector(platform("linux", "arm64", "v8"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -623,6 +623,18 @@ oci {
         dockerHub {
             optionalCredentials()
         }
+        // The eclipse-temurin base image is served from ECR Public (PLT-1261). The registry host, namespace and
+        // group are read from oci.versions.toml so the image is declared in exactly one place; anonymous pulls
+        // need no credentials. exclusiveContent keeps this group from also being looked up on Docker Hub.
+        registry(ociImages.eclipse.temurin.registry!!) {
+            url = uri("https://${ociImages.eclipse.temurin.registry}")
+            exclusiveContent { includeGroup(ociImages.eclipse.temurin.group) }
+        }
+    }
+    imageMapping {
+        mapGroup(ociImages.eclipse.temurin.group) {
+            toImage(nameSpec("${ociImages.eclipse.temurin.namespace}/") + name)
+        }
     }
     imageDefinitions.register("main") {
         allPlatforms {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,8 +76,8 @@ graalvm-native = { id = "org.graalvm.buildtools.native", version = "0.11.5" }
 launch4j = { id = "edu.sc.seis.launch4j", version = "4.0.0" }
 license = { id = "com.hivemq.tools.license", version = "1.3.6" }
 nebula-ospackage = { id = "com.netflix.nebula.ospackage", version = "12.3.0" }
-oci = { id = "io.github.sgtsilvio.gradle.oci", version = "0.27.0" }
-ociVersionCatalog = { id = "com.hivemq.tools.oci-version-catalog", version = "0.3.0" }
+oci = { id = "io.github.sgtsilvio.gradle.oci", version = "0.28.0" }
+ociVersionCatalog = { id = "com.hivemq.tools.oci-version-catalog", version = "0.4.0" }
 openapi-generator = { id = "org.openapi.generator", version = "7.23.0" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.11" }
 spotless = { id = "com.diffplug.spotless", version = "8.8.0" }

--- a/gradle/oci.versions.toml
+++ b/gradle/oci.versions.toml
@@ -1,5 +1,4 @@
-# Security-patched base image published to ECR Public by hivemq/images (PLT-941).
-# Renovate bumps the digest via the oci.versions.toml custom manager.
+# https://gallery.ecr.aws/y7j2u9c5/base-images/eclipse-temurin
 [[oci]]
 name = "eclipse-temurin"
 image = "public.ecr.aws/y7j2u9c5/base-images/eclipse-temurin"

--- a/gradle/oci.versions.toml
+++ b/gradle/oci.versions.toml
@@ -1,5 +1,5 @@
-# https://gallery.ecr.aws/y7j2u9c5/base-images/eclipse-temurin
+# https://gallery.ecr.aws/hivemq/base-images/eclipse-temurin
 [[oci]]
 name = "eclipse-temurin"
-image = "public.ecr.aws/y7j2u9c5/base-images/eclipse-temurin"
-reference = "21-jre-noble@sha256:aea6de429229caa8aadf712d648e59ef22ce54e2690a857103cde797fbfd2170"
+image = "public.ecr.aws/hivemq/base-images/eclipse-temurin"
+reference = "21-jre-noble@sha256:5e349bf28c22a00d7ca2dea836586725698ee7252a178ea94c40ba45a59ec4a0"

--- a/gradle/oci.versions.toml
+++ b/gradle/oci.versions.toml
@@ -1,5 +1,6 @@
-# https://hub.docker.com/_/eclipse-temurin/tags?name=21-jre-noble
+# Security-patched base image published to ECR Public by hivemq/images (PLT-941).
+# Renovate bumps the digest via the oci.versions.toml custom manager.
 [[oci]]
 name = "eclipse-temurin"
-image = "library/eclipse-temurin"
-reference = "21-jre-noble@sha256:373787d1d45a87f084fda43e7de0e9acf5eedee049446efac738f13587ec4c64"
+image = "public.ecr.aws/y7j2u9c5/base-images/eclipse-temurin"
+reference = "21-jre-noble@sha256:aea6de429229caa8aadf712d648e59ef22ce54e2690a857103cde797fbfd2170"


### PR DESCRIPTION
## What

Points the `eclipse-temurin` base image — the base layer of the published mqtt-cli OCI image — at the security-patched image published to **ECR Public** by `hivemq/images` (PLT-941), instead of the upstream Docker Hub image. It is the only image in this catalog.

| | before | after |
|---|---|---|
| `image` | `library/eclipse-temurin` | `public.ecr.aws/y7j2u9c5/base-images/eclipse-temurin` |
| digest | `sha256:373787d1…` (Docker Hub) | `sha256:aea6de42…` (ECR Public, current 21-jre-noble) |

## Prerequisites — both landed ✅

Originally opened against unreleased plugin versions; both have since merged and published:

- **gradle-oci `0.28.0`** — ECR Public auth fix (SgtSilvio/gradle-oci#141, merged 2026-07-17), published 2026-07-17.
- **oci-version-catalog `0.4.0`** — registry-qualified image support (hivemq/hivemq-oci-version-catalog-gradle-plugin#16, merged 2026-07-17), published 2026-07-17.

Verified end-to-end against the **released** plugins with this exact configuration: the base image pulls anonymously from ECR Public (17 blobs / 202 MB). No credentials, OIDC or CI auth changes. The shared `oci.versions.toml` Renovate manager keeps the digest fresh.
